### PR TITLE
fix:notify template list filtered by TenantID always get empty result

### DIFF
--- a/pkg/notify/registry/template/storage/storage.go
+++ b/pkg/notify/registry/template/storage/storage.go
@@ -48,6 +48,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, notifyClient *noti
 		NewFunc:                  func() runtime.Object { return &notify.Template{} },
 		NewListFunc:              func() runtime.Object { return &notify.TemplateList{} },
 		DefaultQualifiedResource: notify.Resource("templates"),
+		PredicateFunc:            templatestrategy.MatchTemplate,
 		ReturnDeletedObject:      true,
 
 		CreateStrategy: strategy,
@@ -57,6 +58,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, notifyClient *noti
 	}
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
+		AttrFunc:    templatestrategy.GetAttrs,
 	}
 
 	if err := store.CompleteWithOptions(options); err != nil {


### PR DESCRIPTION
Tke list function will always filtered by TenantID, but PredicateFunc and AttrFunc not set in the template module which lead to an empty result.