### PR TITLE
Optimized listing deployment events

### DIFF
--- a/pkg/platform/util/client.go
+++ b/pkg/platform/util/client.go
@@ -51,6 +51,8 @@ import (
 
 const (
 	contextName = "tke"
+	clientQPS   = 100
+	clientBurst = 200
 )
 
 // ClientSetByCluster returns the backend kubernetes clientSet by given cluster object
@@ -435,6 +437,8 @@ func BuildClientSet(cluster *platform.Cluster, credential *platform.ClusterCrede
 		log.Error("Build cluster config error", log.String("clusterName", cluster.ObjectMeta.Name), log.Err(err))
 		return nil, err
 	}
+	restConfig.QPS = clientQPS
+	restConfig.Burst = clientBurst
 	return kubernetes.NewForConfig(restConfig)
 }
 


### PR DESCRIPTION
Fixes #50 

This PR fixes:
- Requested events of the deployment and its replicaSets and pods in parallel.
- Filtered events from the resources of different deployments with the same labels.