### PR TITLE
check dst file sha256sum before ssh copy

### DIFF
--- a/pkg/util/ssh/ssh.go
+++ b/pkg/util/ssh/ssh.go
@@ -194,7 +194,7 @@ func (s *SSH) CopyFile(src, dst string) error {
 	}
 	hashFile := dst + ".sha256"
 	buffer := new(bytes.Buffer)
-	buffer.WriteString(fmt.Sprintf("%s %s", srcHash, src))
+	buffer.WriteString(fmt.Sprintf("%s %s", srcHash, dst))
 	_ = s.WriteFile(buffer, hashFile)
 	_, err = s.CombinedOutput(fmt.Sprintf("sha256sum --check --status %s", hashFile))
 	if err == nil { // means dst exist and same as src


### PR DESCRIPTION
What happened:  
The original code tries to run `sha256sum` on the remote machine before copy, but the file to be checked in `.sha256` file is wrong, which means the check always fail

fixes #126 