### PR TITLE
Fix gateway auth-api proxy config and create admin user conflict

### DIFF
--- a/cmd/tke-auth-api/app/config/config.go
+++ b/cmd/tke-auth-api/app/config/config.go
@@ -91,9 +91,6 @@ type Config struct {
 	APIKeyAuthn          *authenticator.APIKeyAuthenticator
 	Authorizer           authorizer.Authorizer
 	CasbinReloadInterval time.Duration
-	TenantID             string
-	TenantAdmin          string
-	TenantAdminSecret    string
 	PrivilegedUsername   string
 }
 
@@ -202,9 +199,6 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 		TokenAuthn:                     tokenAuth,
 		APIKeyAuthn:                    apiKeyAuth,
 		Authorizer:                     aggregateAuthz,
-		TenantID:                       opts.Auth.InitTenantID,
-		TenantAdmin:                    opts.Auth.TenantAdmin,
-		TenantAdminSecret:              opts.Auth.TenantAdminSecret,
 		PrivilegedUsername:             opts.Authentication.PrivilegedUsername,
 		CasbinReloadInterval:           opts.Authorization.CasbinReloadInterval,
 	}, nil
@@ -384,7 +378,7 @@ func setupDefaultClient(store dexstorage.Storage, auth *options.AuthOptions) err
 		}
 
 		// Create a default connector
-		if err = store.CreateClient(cli); err != nil {
+		if err = store.CreateClient(cli); err != nil && err != dexstorage.ErrAlreadyExists {
 			return err
 		}
 	}

--- a/cmd/tke-auth-api/app/options/auth.go
+++ b/cmd/tke-auth-api/app/options/auth.go
@@ -36,8 +36,6 @@ const (
 	flagAuthInitTenantID           = "init-tenant-id"
 	flagAuthInitIDPAdmins          = "init-idp-administrators"
 	flagAuthLDAPConfigFile         = "ldap-config-file"
-	flagAuthTenantAdmin            = "tenant-admin"
-	flagAuthTenantAdminSecret      = "tenant-admin-secret"
 	flagAuthInitClientID           = "init-client-id"
 	flagAuthInitClientSecret       = "init-client-secret"
 	flagAuthInitClientRedirectUris = "init-client-redirect-uris"
@@ -50,8 +48,6 @@ const (
 	configAuthInitTenantID           = "auth.init_tenant_id"
 	configAuthInitIDPAdmins          = "auth.init_idp_administrators"
 	configAuthLDAPConfigFile         = "auth.ldap_config_file"
-	configAuthTenantAdmin            = "auth.tenant_admin"
-	configAuthTenantAdminSecret      = "auth.tenant_admin_secret"
 	configAuthInitClientID           = "auth.init_client_id"
 	configAuthInitClientSecret       = "auth.init_client_secret"
 	configAuthInitClientRedirectUris = "auth.init_client_redirect_uris"
@@ -65,8 +61,6 @@ type AuthOptions struct {
 	InitTenantID           string
 	InitIDPAdmins          []string
 	LdapConfigFile         string
-	TenantAdmin            string
-	TenantAdminSecret      string
 	InitClientID           string
 	InitClientSecret       string
 	InitClientRedirectUris []string
@@ -108,14 +102,6 @@ func (o *AuthOptions) AddFlags(fs *pflag.FlagSet) {
 		"Config file path for ldap ldap, must specify if init-tenant-type is ldap.")
 	_ = viper.BindPFlag(configAuthLDAPConfigFile, fs.Lookup(flagAuthLDAPConfigFile))
 
-	fs.String(flagAuthTenantAdmin, o.TenantAdmin,
-		"Default tenant admin name for local tke identity provider will be created when started.")
-	_ = viper.BindPFlag(configAuthTenantAdmin, fs.Lookup(flagAuthTenantAdmin))
-
-	fs.String(flagAuthTenantAdminSecret, o.TenantAdminSecret,
-		"Password for default tenant admin login.")
-	_ = viper.BindPFlag(configAuthTenantAdminSecret, fs.Lookup(flagAuthTenantAdminSecret))
-
 	fs.String(flagAuthInitClientID, o.InitClientID,
 		"Default client id will be created when started.")
 	_ = viper.BindPFlag(configAuthInitClientID, fs.Lookup(flagAuthInitClientID))
@@ -153,12 +139,6 @@ func (o *AuthOptions) ApplyFlags() []error {
 	}
 
 	o.InitIDPAdmins = viper.GetStringSlice(configAuthInitIDPAdmins)
-
-	o.TenantAdmin = viper.GetString(configAuthTenantAdmin)
-	o.TenantAdminSecret = viper.GetString(configAuthTenantAdminSecret)
-	if len(o.TenantAdmin) == 0 || len(o.TenantAdminSecret) == 0 {
-		errs = append(errs, fmt.Errorf("--%s and --%s must be specified", flagAuthTenantAdmin, flagAuthTenantAdminSecret))
-	}
 
 	o.InitClientID = viper.GetString(configAuthInitClientID)
 	o.InitClientSecret = viper.GetString(configAuthInitClientSecret)

--- a/cmd/tke-auth-api/app/server.go
+++ b/cmd/tke-auth-api/app/server.go
@@ -69,9 +69,6 @@ func createAPIServerConfig(cfg *config.Config) *apiserver.Config {
 			APIKeyAuthn:             cfg.APIKeyAuthn,
 			Authorizer:              cfg.Authorizer,
 			CasbinReloadInterval:    cfg.CasbinReloadInterval,
-			TenantID:                cfg.TenantID,
-			TenantAdmin:             cfg.TenantAdmin,
-			TenantAdminSecret:       cfg.TenantAdminSecret,
 			PrivilegedUsername:      cfg.PrivilegedUsername,
 		},
 	}

--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1511,7 +1511,6 @@ func (t *TKE) installTKEAuthAPI() error {
 		"Image":            images.Get().TKEAuthAPI.FullName(),
 		"OIDCClientSecret": t.readOrGenerateString(constants.OIDCClientSecretFile),
 		"AdminUsername":    t.Para.Config.Auth.TKEAuth.Username,
-		"AdminPassword":    string(t.Para.Config.Auth.TKEAuth.Password),
 		"TenantID":         t.Para.Config.Auth.TKEAuth.TenantID,
 		"RedirectHosts":    redirectHosts,
 	}

--- a/cmd/tke-installer/app/installer/manifests/tke-auth-api/tke-auth-api.yaml
+++ b/cmd/tke-installer/app/installer/manifests/tke-auth-api/tke-auth-api.yaml
@@ -104,6 +104,7 @@ data:
     [authentication]
     token_auth_file = "/app/certs/token.csv"
     client_ca_file = "/app/certs/ca.crt"
+    privileged_username = "{{ .AdminUsername }}"
 
       [authentication.requestheader]
       client_ca_file = "/app/certs/ca.crt"
@@ -112,8 +113,6 @@ data:
 
     [auth]
     assets_path = "/app/web/auth"
-    tenant_admin = "{{ .AdminUsername }}"
-    tenant_admin_secret = "{{ .AdminPassword }}"
     init_client_id = "{{ .TenantID }}"
     init_client_secret = "{{ .OIDCClientSecret }}"
     init_client_redirect_uris = [

--- a/cmd/tke-installer/app/installer/manifests/tke-gateway/tke-gateway.yaml
+++ b/cmd/tke-installer/app/installer/manifests/tke-gateway/tke-gateway.yaml
@@ -126,7 +126,7 @@ data:
     components:
 {{- if .EnableAuth }}
       auth:
-        address: https://tke-auth
+        address: https://tke-auth-api
         passthrough:
           caFile: /app/certs/ca.crt
 {{- end }}

--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -186,7 +186,8 @@ previous step. For macOS, the path is usually /Users/${username}/Library/Applica
       "servers": ["http://127.0.0.1:2379"]
     },
     "authentication": {
-      "token_auth_file": "_debug/token.csv"
+      "token_auth_file": "_debug/token.csv",
+      "privileged_username": "admin"
     },
     "generic": {
       "external_hostname": "localhost",
@@ -194,8 +195,6 @@ previous step. For macOS, the path is usually /Users/${username}/Library/Applica
     },
     "auth": {
       "assets_path": "./pkg/auth/web",
-      "tenant_admin": "admin",
-      "tenant_admin_secret": "secret",
       "init_client_id": "client",
       "init_client_secret": "secret",
       "init_client_redirect_uris": [

--- a/pkg/auth/apiserver/apiserver.go
+++ b/pkg/auth/apiserver/apiserver.go
@@ -77,9 +77,6 @@ type ExtraConfig struct {
 	APIKeyAuthn          *authenticator.APIKeyAuthenticator
 	Authorizer           authorizer.Authorizer
 	CasbinReloadInterval time.Duration
-	TenantID             string
-	TenantAdmin          string
-	TenantAdminSecret    string
 	PrivilegedUsername   string
 }
 
@@ -215,15 +212,13 @@ func (c completedConfig) registerHooks(dexHandler *identityprovider.DexHander, s
 
 	apiSigningKeyHook := authenticator.NewAPISigningKeyHookHandler(authClient)
 
-	identityHook := authenticator.NewAdminIdentityHookHandler(authClient, c.ExtraConfig.TenantID, c.ExtraConfig.TenantAdmin, c.ExtraConfig.TenantAdminSecret)
-
 	localIdpHook := local.NewLocalHookHandler(authClient, c.ExtraConfig.VersionedInformers)
 	ldapIdpHook := ldap.NewLdapHookHandler(authClient)
 
 	authVersionedClient := versionedclientset.NewForConfigOrDie(s.LoopbackClientConfig)
 	adapterHook := local2.NewAdapterHookHandler(authVersionedClient, c.ExtraConfig.CasbinEnforcer, c.ExtraConfig.VersionedInformers, c.ExtraConfig.CasbinReloadInterval)
 
-	return []genericapiserver.PostStartHookProvider{dexHook, apiSigningKeyHook, identityHook, localIdpHook, ldapIdpHook, adapterHook}
+	return []genericapiserver.PostStartHookProvider{dexHook, apiSigningKeyHook, localIdpHook, ldapIdpHook, adapterHook}
 }
 
 // installCasbinPreStopHook is used to register preStop hook to stop casbin enforcer sync.

--- a/pkg/auth/authorization/aggregation/aggregation.go
+++ b/pkg/auth/authorization/aggregation/aggregation.go
@@ -55,7 +55,7 @@ func NewAuthorizer(authClient authinternalclient.AuthInterface, authorizationOpt
 		authorizers = append(authorizers, abacAuthorizer)
 	}
 
-	authorizers = append(authorizers, local.NewAuthorizer(authClient, enforcer, authOpts.TenantAdmin, privilegedUsername))
+	authorizers = append(authorizers, local.NewAuthorizer(authClient, enforcer, privilegedUsername))
 
 	return union.New(authorizers...), nil
 }

--- a/pkg/auth/authorization/local/authorizer.go
+++ b/pkg/auth/authorization/local/authorizer.go
@@ -42,7 +42,6 @@ var (
 // Authorizer implement the authorize interface that use local repository to
 // authorize the subject access review.
 type Authorizer struct {
-	tenantAdmin        string
 	privilegedUsername string
 
 	authClient authinternalclient.AuthInterface
@@ -50,9 +49,8 @@ type Authorizer struct {
 }
 
 // NewAuthorizer creates a local repository authorizer and returns it.
-func NewAuthorizer(authClient authinternalclient.AuthInterface, enforcer *casbin.SyncedEnforcer, tenantAdmin string, privilegedUsername string) *Authorizer {
+func NewAuthorizer(authClient authinternalclient.AuthInterface, enforcer *casbin.SyncedEnforcer, privilegedUsername string) *Authorizer {
 	return &Authorizer{
-		tenantAdmin:        tenantAdmin,
 		privilegedUsername: privilegedUsername,
 		authClient:         authClient,
 		enforcer:           enforcer,
@@ -83,8 +81,8 @@ func (a *Authorizer) Authorize(ctx context.Context, attr authorizer.Attributes) 
 		}
 	}
 
-	// First check if user is tenantAdmin or privileged
-	if subject == a.tenantAdmin || subject == a.privilegedUsername {
+	// First check if user is privileged
+	if subject == a.privilegedUsername {
 		return authorizer.DecisionAllow, "", nil
 	}
 


### PR DESCRIPTION
1. Fix tke-gateway proxy tke-auth-api wrong name #134 
2. Fix create the same admin user if pods for tke-auth-api started at the same time
![image](https://user-images.githubusercontent.com/5778883/74514502-aa7fdc80-4f47-11ea-91e4-462b9d6c0199.png)
