### PR TITLE
don't delete Header Authorization

### DIFF
--- a/pkg/apiserver/filter/authentication.go
+++ b/pkg/apiserver/filter/authentication.go
@@ -131,7 +131,7 @@ func WithAuthentication(handler http.Handler, auth authenticator.Request, failed
 		}
 
 		// authorization header is not required anymore in case of a successful authentication.
-		req.Header.Del("Authorization")
+		// req.Header.Del("Authorization")
 
 		req = req.WithContext(genericapirequest.WithUser(req.Context(), resp.User))
 


### PR DESCRIPTION
don't delete Header Authorization in /pkg/apiserver/filter/authentication.go#L134,it's used by chartmuseum in /pkg/registry/util/authentication/authentication.go#L32