### PR TITLE
Upgrade galaxy/ipam to v1.0.1

### DIFF
--- a/pkg/platform/controller/addon/ipam/images/images.go
+++ b/pkg/platform/controller/addon/ipam/images/images.go
@@ -48,7 +48,7 @@ func (c Components) Get(name string) *containerregistry.Image {
 
 var versionMap = map[string]Components{
 	LatestVersion: {
-		IPAM: containerregistry.Image{Name: "galaxy-ipam", Tag: "v1.0.0"},
+		IPAM: containerregistry.Image{Name: "galaxy-ipam", Tag: "v1.0.1"},
 	},
 }
 

--- a/pkg/platform/controller/addon/ipam/ipam_controller.go
+++ b/pkg/platform/controller/addon/ipam/ipam_controller.go
@@ -468,6 +468,11 @@ func crIPAM() *rbacv1.ClusterRole {
 				Resources: []string{"customresourcedefinitions"},
 				Verbs:     []string{"*"},
 			},
+			{
+				APIGroups: []string{"apps.tkestack.io"},
+				Resources: []string{"tapps"},
+				Verbs:     []string{"list", "watch"},
+			},
 		},
 	}
 }
@@ -484,7 +489,7 @@ func deploymentIPAM(version string) *appsv1.Deployment {
 			Namespace: metav1.NamespaceSystem,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(2),
+			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "galaxy-ipam"},
 			},

--- a/pkg/platform/provider/baremetal/phases/galaxy/images/images.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/images/images.go
@@ -49,7 +49,7 @@ func (c Components) Get(name string) *containerregistry.Image {
 
 var versionMap = map[string]Components{
 	LatestVersion: {
-		GalaxyDaemon: containerregistry.Image{Name: "galaxy", Tag: "v1.0.0"},
+		GalaxyDaemon: containerregistry.Image{Name: "galaxy", Tag: "v1.0.1"},
 		Flannel:      containerregistry.Image{Name: "flannel", Tag: "v0.10.0-amd64"},
 	},
 }

--- a/pkg/platform/provider/baremetal/phases/galaxy/template.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/template.go
@@ -43,7 +43,7 @@ spec:
       containers:
       - image: galaxy:1.0.0-alpha
         command: ["/bin/sh"]
-        args: ["-c", "cp -p /etc/cni/net.d/00-galaxy.conf /host/etc/cni/net.d/; cp -p /opt/cni/bin/* /host/opt/cni/bin/; /usr/bin/galaxy --logtostderr=true --v=3"]
+        args: ["-c", "cp -p /etc/galaxy/cni/00-galaxy.conf /etc/cni/net.d/; cp -p /opt/cni/galaxy/bin/galaxy-sdn /opt/cni/galaxy/bin/loopback /opt/cni/bin/; /usr/bin/galaxy --logtostderr=true --v=3"]
         name: galaxy
         resources:
           requests:
@@ -56,18 +56,16 @@ spec:
           mountPath: /var/run/galaxy/
         - name: flannel-run
           mountPath: /run/flannel
-        - name: kube-config
-          mountPath: /host/etc/kubernetes/
         - name: galaxy-log
           mountPath: /data/galaxy/logs
         - name: galaxy-etc
           mountPath: /etc/galaxy
         - name: cni-config
-          mountPath: /host/etc/cni/net.d/
+          mountPath: /etc/cni/net.d/
         - name: cni-bin
-          mountPath: /host/opt/cni/bin
+          mountPath: /opt/cni/bin
         - name: cni-etc
-          mountPath: /etc/cni/net.d
+          mountPath: /etc/galaxy/cni
         - name: cni-state
           mountPath: /var/lib/cni
         - name: docker-sock
@@ -83,9 +81,6 @@ spec:
       - name: flannel-run
         hostPath:
           path: /run/flannel
-      - name: kube-config
-        hostPath:
-          path: /etc/kubernetes/
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin


### PR DESCRIPTION
- Support for dynamic network config. Load unknown network config from /etc/cni/net.d/ to co-work with other cni plugins. This makes ENI network co-work with the default global vpc route network on qcloud.
- IPAM supports allocating floatingip to TApp/replicasets pods.
- Fix IPAM corner cases resulting of unreleased ips.
