### PR TITLE
fix: add node name env for galaxy daemonsets

### DIFF
--- a/pkg/platform/provider/baremetal/phases/galaxy/template.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/template.go
@@ -45,6 +45,11 @@ spec:
         command: ["/bin/sh"]
         args: ["-c", "cp -p /etc/galaxy/cni/00-galaxy.conf /etc/cni/net.d/; cp -p /opt/cni/galaxy/bin/galaxy-sdn /opt/cni/galaxy/bin/loopback /opt/cni/bin/; /usr/bin/galaxy --logtostderr=true --v=3"]
         name: galaxy
+        env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
ref: https://github.com/tkestack/galaxy/pull/30