### PR TITLE
fix: Only ask users to enable experimental features when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build:
 build.multiarch:
 	@$(MAKE) go.build.multiarch
 
-## image: Build docker images for linux_amd64 platform.
+## image: Build docker images for host arch.
 .PHONY: image
 image:
 	@$(MAKE) image.build
@@ -94,7 +94,7 @@ image:
 image.multiarch:
 	@$(MAKE) image.build.multiarch
 
-## push: Build docker images for linux_amd64 platform and push images to registry.
+## push: Build docker images for host arch and push images to registry.
 .PHONY: push
 push:
 	@$(MAKE) image.push
@@ -104,7 +104,7 @@ push:
 push.multiarch:
 	@$(MAKE) image.push.multiarch
 
-## manifest: Build docker images for linux_amd64 platform and push manifest list to registry.
+## manifest: Build docker images for host arch and push manifest list to registry.
 .PHONY: manifest
 manifest:
 	@$(MAKE) image.manifest.push

--- a/build/lib/common.mk
+++ b/build/lib/common.mk
@@ -61,8 +61,8 @@ ifeq ($(origin PLATFORM), undefined)
 		GOARCH := $(shell go env GOARCH)
 	endif
 	PLATFORM := $(GOOS)_$(GOARCH)
-	# Use linux_amd64 as the default platform when building images
-	IMAGE_PLAT := linux_amd64
+	# Use linux as the default OS when building images
+	IMAGE_PLAT := linux_$(GOARCH)
 else
 	GOOS := $(word 1, $(subst _, ,$(PLATFORM)))
 	GOARCH := $(word 2, $(subst _, ,$(PLATFORM)))

--- a/build/lib/create-manifest.sh
+++ b/build/lib/create-manifest.sh
@@ -1,4 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Tencent is pleased to support the open source community by making TKEStack
+# available.
+#
+# Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 REGISTRY_PREFIX=${REGISTRY_PREFIX:-"tkestack"}
 PLATFORMS=${PLATFORMS:-"linux_amd64 linux_arm64"}


### PR DESCRIPTION
1. Only ask users to enable the experimental features of Docker when `cross-building` docker images.
2. Check Docker API version instead of Docker version. 