### PR TITLE
fix: add --iface=$(HOST_IP) arg in flannel

### DIFF
--- a/pkg/platform/provider/baremetal/phases/galaxy/template.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/template.go
@@ -177,6 +177,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --iface=$(HOST_IP)
         resources:
           requests:
             cpu: "100m"
@@ -195,6 +196,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         volumeMounts:
         - name: run
           mountPath: /run


### PR DESCRIPTION
without this arg, flannel will auto-detect host ip as outside encapsulation
packet's source ip. If there're muilt-ips in host net interface and the `first` ip is
not what we need, network may fail.

Signed-off-by: forrestchen <forrestchen@tencent.com>