### PR TITLE
fix machine & cluster controller parameters not read

### DIFF
--- a/cmd/tke-platform-controller/app/options/clustercontroller.go
+++ b/cmd/tke-platform-controller/app/options/clustercontroller.go
@@ -83,3 +83,11 @@ func (o *ClusterControllerOptions) Validate() []error {
 	errs := []error{}
 	return errs
 }
+
+// ApplyFlags parsing parameters from the command line or configuration file
+// to the options instance.
+func (o *ClusterControllerOptions) ApplyFlags() []error{
+	o.ClusterSyncPeriod = viper.GetDuration(configClusterSyncPeriod)
+	o.ConcurrentClusterSyncs = viper.GetInt(configConcurrentClusterSyncs)
+	return nil
+}

--- a/cmd/tke-platform-controller/app/options/machinecontroller.go
+++ b/cmd/tke-platform-controller/app/options/machinecontroller.go
@@ -83,3 +83,11 @@ func (o *MachineControllerOptions) Validate() []error {
 	errs := []error{}
 	return errs
 }
+
+// ApplyFlags parsing parameters from the command line or configuration file
+// to the options instance.
+func (o *MachineControllerOptions) ApplyFlags() []error{
+	o.MachineSyncPeriod = viper.GetDuration(configMachineSyncPeriod)
+	o.ConcurrentMachineSyncs = viper.GetInt(configConcurrentMachineSyncs)
+	return nil
+}

--- a/cmd/tke-platform-controller/app/options/options.go
+++ b/cmd/tke-platform-controller/app/options/options.go
@@ -85,6 +85,8 @@ func (o *Options) ApplyFlags() []error {
 	errs = append(errs, o.PlatformAPIClient.ApplyFlags()...)
 	errs = append(errs, o.Registry.ApplyFlags()...)
 	errs = append(errs, o.FeatureOptions.ApplyFlags()...)
+	errs = append(errs, o.ClusterController.ApplyFlags()...)
+	errs = append(errs, o.MachineController.ApplyFlags()...)
 
 	return errs
 }


### PR DESCRIPTION
the following parameters added in commit 4df559f6b11e33e255adc649f85877030f01ad4e are read from config file but not set to `options`:
* `controller.machine_sync_period`
* `controller.concurrent_machine_syncs`
* `controller.cluster_sync_period`
* `controller.concurrent_cluster_syncs`