### PR TITLE
fix: get rid of empty samples of metric query for thanos backend

### DIFF
--- a/cmd/tke-platform-controller/app/options/feature.go
+++ b/cmd/tke-platform-controller/app/options/feature.go
@@ -60,7 +60,7 @@ func (o *FeatureOptions) ApplyFlags() []error {
 
 	switch o.MonitorStorageType {
 	case "":
-	case "influxdb", "elasticsearch", "es", "influxDB":
+	case "influxdb", "elasticsearch", "es", "influxDB", "thanos":
 		if len(o.MonitorStorageAddresses) == 0 {
 			errs = append(errs, fmt.Errorf("must specify %s server address", o.MonitorStorageType))
 		}

--- a/pkg/monitor/storage/thanos/metric/metric.go
+++ b/pkg/monitor/storage/thanos/metric/metric.go
@@ -229,6 +229,16 @@ func MergeResult(results model.Matrix, timestamp string, groupByWithoutTimestamp
 		}
 	}
 
+	// get rid of empty values as samples may not fulfill all the time gap
+	for i, v := range values {
+		if v.([]interface{})[0] == nil {
+			continue
+		} else {
+			values = values[i:]
+			break
+		}
+	}
+
 	log.Debugf("columes %v", columns)
 	log.Debugf("values %v", values)
 	return &types.MetricMergedResult{


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>