### PR TITLE
fix tenant not read from registry domain

### DIFF
--- a/pkg/registry/util/request/request.go
+++ b/pkg/registry/util/request/request.go
@@ -21,6 +21,7 @@ package request
 import (
 	"net/http"
 	"strings"
+
 	utilhttp "tkestack.io/tke/pkg/util/http"
 )
 
@@ -37,7 +38,9 @@ func TenantID(req *http.Request, domainSuffix string, defaultTenant string) stri
 		if strings.HasSuffix(tenant, ".") {
 			tenant = strings.TrimSuffix(tenant, ".")
 		}
-		return tenant
+		if tenant != "" {
+			return tenant
+		}
 	}
 	return defaultTenant
 }

--- a/pkg/util/http/request.go
+++ b/pkg/util/http/request.go
@@ -19,15 +19,15 @@
 package http
 
 import (
-	"net"
 	"net/http"
+	"strings"
 )
 
 // DomainFromRequest returns the host by given http request.
 func DomainFromRequest(req *http.Request) string {
-	host, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		return ""
+	i := strings.Index(req.Host, ":")
+	if i < 0 {
+		return req.Host
 	}
-	return host
+	return req.Host[:i]
 }


### PR DESCRIPTION
the function `DomainFromRequest` is supposed to extract tenantID from request host, such as `default` from `default.registry.com`, but `SplitHostPort` in `DomainFromRequest` reports error if there is no `:port` in `req.Host`, which makes the function `TenantID` always return the `defaultTenant`