### PR TITLE
refactor: wrap docker commands and extract commands from tke-installer

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -22,6 +22,8 @@ import "github.com/thoas/go-funk"
 
 var (
 	Archs            = []string{"amd64", "arm64"}
+	Arm64			 = "arm64"
+	Arm64Variants	 = []string{"v8", "unknown"}
 	OSs              = []string{"linux"}
 	K8sVersions      = []string{"1.14.10", "1.16.6"}
 	K8sVersionsWithV = funk.Map(K8sVersions, func(s string) string {

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -1,0 +1,249 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package docker
+
+import (
+"fmt"
+"io"
+"os/exec"
+"regexp"
+"strings"
+"tkestack.io/tke/pkg/spec"
+
+pkgerrors "github.com/pkg/errors"
+)
+
+// Docker represents an external docker command being prepared or run.
+//
+// A Docker instance can be reused after calling its methods.
+type Docker struct {
+	// Stdout and Stderr specify the process's standard output and error.
+	//
+	// If either is nil, Cmd Run connects the corresponding file descriptor
+	// to the null device (os.DevNull).
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func New() *Docker {
+	docker := &Docker{}
+	return docker
+}
+
+func (d *Docker) runCmd(cmdString string) error {
+	cmd := exec.Command("sh", "-c", cmdString)
+	cmd.Stdout = d.Stdout
+	cmd.Stderr = d.Stderr
+	return cmd.Run()
+}
+
+func (d *Docker) getCmdOutput(cmdString string) ([]byte, error) {
+	// print cmdString before run
+	if d.Stdout != nil {
+		_, _ = d.Stdout.Write([]byte(cmdString + "\n"))
+	}
+	cmd := exec.Command("sh", "-c", cmdString)
+	return cmd.Output()
+}
+
+// Get docker images which match given image prefix
+func (d *Docker) GetImages(imagePrefix string) ([]string, error) {
+	cmdString := fmt.Sprintf("docker images --format='{{.Repository}}:{{.Tag}}' --filter='reference=%s'", imagePrefix)
+	out, err := d.getCmdOutput(cmdString)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "docker images error")
+	}
+	images := strings.Split(strings.TrimSpace(string(out)), "\n")
+	return images, nil
+}
+
+// Push a image which has a suffix about arch.
+// Then create/amend local manifest of the image,
+// and push the updated local manifest to registry if need.
+// (For speed up processing, it is better to push manifests after all changes have made)
+func (d *Docker) PushImageWithArch(image string, manifestName string,
+	arch string, variant string, needPushManifest bool) error {
+	err := d.PushImage(image)
+	if err != nil {
+		return err
+	}
+
+	err = d.CreateManifest(image, manifestName)
+	if err != nil {
+		return err
+	}
+
+	err = d.AnnotateManifest(image, manifestName, arch, variant)
+	if err != nil {
+		return err
+	}
+
+	if needPushManifest {
+		err = d.PushManifest(manifestName, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// For arm64 images, we need to add another two variants when annotating manifest
+// variant: unknown, v8
+func (d *Docker) PushArm64Variants(image string, manifestName string) error {
+	for _, variant := range spec.Arm64Variants {
+		variantImage := fmt.Sprintf("%s-%s", image, variant)
+
+		err := d.TagImage(image, variantImage)
+		if err != nil {
+			return err
+		}
+
+		err = d.PushImageWithArch(variantImage, manifestName, spec.Arm64, variant, false)
+		if err != nil {
+			return err
+		}
+
+		err = d.RemoveImage(variantImage)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Docker) GetNameArchTag(image string) (name string, arch string, tag string, err error) {
+	name, tag, err = d.SplitImageNameAndTag(image)
+	if err != nil { // invalid image
+		return "", "", "", err
+	}
+	name, arch = d.SplitNameAndArch(name)
+	return
+}
+
+func (d *Docker) SplitImageNameAndTag(image string) (name string, tag string, err error) {
+	nameAndTag := strings.Split(image, ":")
+	if len(nameAndTag) != 2 {
+		return "", "", fmt.Errorf("fail to get name and tag for image: %v", image)
+	}
+	if nameAndTag[1] == "<none>" {
+		return "", "", fmt.Errorf("image %s is invalid", image)
+	}
+	return nameAndTag[0], nameAndTag[1], nil
+}
+
+func (d *Docker) SplitNameAndArch(name string) (string, string) {
+	archRegex := regexp.MustCompile(fmt.Sprintf(`(.+)-(%s)$`, strings.Join(spec.Archs, "|")))
+	archMatches := archRegex.FindStringSubmatch(name)
+	if archMatches == nil {
+		return name, ""
+	}
+	return archMatches[1], archMatches[2]
+}
+
+// Load from a tar archive file
+func (d *Docker) LoadImages(imagesFile string) error {
+	cmdString := fmt.Sprintf("docker load -i %s", imagesFile)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker load error")
+	}
+	return nil
+}
+
+// Tag a image
+func (d *Docker) TagImage(srcImage string, destImage string) error {
+	cmdString := fmt.Sprintf("docker tag %s %s", srcImage, destImage)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker tag error")
+	}
+	return nil
+}
+
+// Push a image
+func (d *Docker) PushImage(image string) error {
+	cmdString := fmt.Sprintf("docker push %s", image)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker push error")
+	}
+	return nil
+}
+
+// Remove a image
+func (d *Docker) RemoveImage(image string) error {
+	cmdString := fmt.Sprintf("docker rmi %s ", image)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker tag error")
+	}
+	return nil
+}
+
+// Clear all local manifest lists
+// Better to call before you want to create a manifest list
+func (d *Docker) ClearLocalManifests() error {
+	cmdString := "rm -rf ${HOME}/.docker/manifests/"
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "remove local manifest files error")
+	}
+	return nil
+}
+
+// Create a local manifest list. !IMPORTANT: local,local,local!
+func (d *Docker) CreateManifest(image string, manifestName string) error {
+	cmdString := fmt.Sprintf("docker manifest create --amend --insecure %s %s", manifestName, image)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker manifest create error")
+	}
+	return nil
+}
+
+// Add additional information to a local image manifest. !IMPORTANT: local,local,local!
+func (d *Docker) AnnotateManifest(image string, manifestName string, arch string, variant string) error {
+	variantArg := ""
+	if variant != "" {
+		variantArg = fmt.Sprintf("--variant %s", variant)
+	}
+	cmdString := fmt.Sprintf("docker manifest annotate %s %s --arch %s %s",
+		manifestName, image, arch, variantArg)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker manifest annotate error")
+	}
+	return nil
+}
+
+// Push a manifest list
+func (d *Docker) PushManifest(manifestName string, needPurge bool) error {
+	purgeArg := ""
+	if needPurge {
+		// Remove the local manifest list after push. !IMPORTANT: Remove local!
+		purgeArg = "--purge"
+	}
+	cmdString := fmt.Sprintf("docker manifest push --insecure %s %s ", purgeArg, manifestName)
+	err := d.runCmd(cmdString)
+	if err != nil {
+		return pkgerrors.Wrap(err, "docker manifest push error")
+	}
+	return nil
+}


### PR DESCRIPTION
1. fix: add two variants (unknown & v8) for arm64 images. 
2. refactor: warp docker commands
3. refactor: push manifest lists after all local changes have made.