### PR TITLE
fix: extend imporResource timeout

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1717,6 +1717,9 @@ func (t *TKE) importResource() error {
 	if err != nil {
 		return err
 	}
+	// default timeout is 5 seconds, but create cluster need more time to validate spec
+	restConfig.Timeout = 120 * time.Second
+
 	client, err := tkeclientset.NewForConfig(restConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

create cluster need more time to validate spec.