### PR TITLE
feat:update galaxy version and change galaxy-ipam service as clusterIP

### DIFF
--- a/pkg/platform/controller/addon/ipam/images/images.go
+++ b/pkg/platform/controller/addon/ipam/images/images.go
@@ -48,7 +48,7 @@ func (c Components) Get(name string) *containerregistry.Image {
 
 var versionMap = map[string]Components{
 	LatestVersion: {
-		IPAM: containerregistry.Image{Name: "galaxy-ipam", Tag: "v1.0.2"},
+		IPAM: containerregistry.Image{Name: "galaxy-ipam", Tag: "v1.0.3"},
 	},
 }
 

--- a/pkg/platform/controller/addon/ipam/ipam_controller.go
+++ b/pkg/platform/controller/addon/ipam/ipam_controller.go
@@ -633,7 +633,7 @@ func serviceIPAM() *corev1.Service {
 				{Name: "scheduler-port", Port: 9040, TargetPort: intstr.FromInt(9040), NodePort: 32760},
 				{Name: "api-port", Port: 9041, TargetPort: intstr.FromInt(9041), NodePort: 32761},
 			},
-			Type: corev1.ServiceTypeNodePort,
+			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
 }

--- a/pkg/platform/provider/baremetal/cluster/manifests.go
+++ b/pkg/platform/provider/baremetal/cluster/manifests.go
@@ -53,7 +53,7 @@ const (
             }
          ],
          "nodeCacheCapable" : false,
-         "urlPrefix" : "http://127.0.0.1:32760/v1"
+         "urlPrefix" : "http://galaxy-ipam:9040/v1"
       }
    ],
    "kind" : "Policy"

--- a/pkg/platform/provider/baremetal/phases/galaxy/images/images.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/images/images.go
@@ -49,7 +49,7 @@ func (c Components) Get(name string) *containerregistry.Image {
 
 var versionMap = map[string]Components{
 	LatestVersion: {
-		GalaxyDaemon: containerregistry.Image{Name: "galaxy", Tag: "v1.0.2"},
+		GalaxyDaemon: containerregistry.Image{Name: "galaxy", Tag: "v1.0.3"},
 		Flannel:      containerregistry.Image{Name: "flannel", Tag: "v0.10.0"},
 	},
 }


### PR DESCRIPTION
update galaxy image version
galaxy ipam use clusterIP service to avoid nodePort issue in some ipvs scenario