### PR TITLE
feat: Disable http debug url (#284)

### DIFF
--- a/cmd/tke-audit-api/app/config/config.go
+++ b/cmd/tke-audit-api/app/config/config.go
@@ -20,9 +20,10 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
-	"path/filepath"
 	generatedopenapi "tkestack.io/tke/api/openapi"
 	"tkestack.io/tke/cmd/tke-audit-api/app/options"
 	"tkestack.io/tke/pkg/apiserver"
@@ -79,6 +80,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.BuildHandlerChainFunc = handler.BuildHandlerChain(ignoredAuthPathPrefixes)
 	genericAPIServerConfig.EnableIndex = false
 	genericAPIServerConfig.EnableDiscovery = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-auth-api/app/config/config.go
+++ b/cmd/tke-auth-api/app/config/config.go
@@ -104,6 +104,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-business-api/app/config/config.go
+++ b/cmd/tke-business-api/app/config/config.go
@@ -66,6 +66,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.BuildHandlerChainFunc = handler.BuildHandlerChain(nil)
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-gateway/app/config/config.go
+++ b/cmd/tke-gateway/app/config/config.go
@@ -99,6 +99,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.LongRunningFunc = filter.LongRunningRequestCheck(sets.NewString(), sets.NewString(), []string{"/"})
 	genericAPIServerConfig.EnableIndex = false
 	genericAPIServerConfig.EnableDiscovery = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-installer/app/app.go
+++ b/cmd/tke-installer/app/app.go
@@ -19,7 +19,6 @@
 package app
 
 import (
-	commonapiserver "k8s.io/apiserver/pkg/server"
 	"tkestack.io/tke/cmd/tke-installer/app/config"
 	"tkestack.io/tke/cmd/tke-installer/app/options"
 	"tkestack.io/tke/pkg/app"
@@ -54,7 +53,6 @@ func run(opts *options.Options) app.RunFunc {
 			return err
 		}
 
-		stopCh := commonapiserver.SetupSignalHandler()
-		return Run(cfg, stopCh)
+		return Run(cfg)
 	}
 }

--- a/cmd/tke-installer/app/run.go
+++ b/cmd/tke-installer/app/run.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Run runs the specified TKE installer. This should never exit.
-func Run(cfg *config.Config, stopCh <-chan struct{}) error {
+func Run(cfg *config.Config) error {
 	installer.New(cfg).Run()
 
 	return nil

--- a/cmd/tke-logagent-api/app/config/config.go
+++ b/cmd/tke-logagent-api/app/config/config.go
@@ -20,11 +20,12 @@ package config
 
 import (
 	"fmt"
+	"time"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/common"
-	"time"
 	versionedclientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformversionedclient "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
 	versionedinformers "tkestack.io/tke/api/client/informers/externalversions"
@@ -54,13 +55,13 @@ type Config struct {
 	PlatformClient                 platformversionedclient.PlatformV1Interface
 }
 
-
 //config relies on options
 func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config, error) {
 	genericAPIServerConfig := genericapiserver.NewConfig(logagent.Codecs)
 	genericAPIServerConfig.BuildHandlerChainFunc = handler.BuildHandlerChain(nil)
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-monitor-api/app/config/config.go
+++ b/cmd/tke-monitor-api/app/config/config.go
@@ -20,12 +20,13 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
+	"time"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/common"
-	"path/filepath"
-	"time"
 	versionedclientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformversionedclient "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
 	versionedinformers "tkestack.io/tke/api/client/informers/externalversions"
@@ -93,6 +94,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.BuildHandlerChainFunc = handler.BuildHandlerChain(nil)
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-notify-api/app/config/config.go
+++ b/cmd/tke-notify-api/app/config/config.go
@@ -20,10 +20,11 @@ package config
 
 import (
 	"fmt"
+	"time"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/client-go/rest"
-	"time"
 	versionedclientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformversionedclient "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
 	versionedinformers "tkestack.io/tke/api/client/informers/externalversions"
@@ -66,6 +67,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.BuildHandlerChainFunc = handler.BuildHandlerChain(ignoreAuthPathPrefixes)
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err

--- a/cmd/tke-platform-api/app/config/config.go
+++ b/cmd/tke-platform-api/app/config/config.go
@@ -76,6 +76,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	)
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if opts.Audit.PolicyFile != "" {
 		p, err := policy.LoadPolicyFromFile(opts.Audit.PolicyFile)

--- a/cmd/tke-registry-api/app/config/config.go
+++ b/cmd/tke-registry-api/app/config/config.go
@@ -20,11 +20,12 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
+	"time"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
-	"path/filepath"
-	"time"
 	versionedclientset "tkestack.io/tke/api/client/clientset/versioned"
 	versionedinformers "tkestack.io/tke/api/client/informers/externalversions"
 	generatedopenapi "tkestack.io/tke/api/openapi"
@@ -101,6 +102,7 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 	genericAPIServerConfig.MaxRequestBodyBytes = chartmuseum.MaxUploadSize
 	genericAPIServerConfig.MergedResourceConfig = apiserver.DefaultAPIResourceConfigSource()
 	genericAPIServerConfig.EnableIndex = false
+	genericAPIServerConfig.EnableProfiling = false
 
 	if err := opts.Generic.ApplyTo(genericAPIServerConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
close http debug path host:port/debug/pprof;
in tke-install pprof  is installed in default http mux
while tke-xx-api pprof is installed by apiserver restful mux