### PR TITLE
fix(galaxy-ipam): fix galaxy-ipam service

### DIFF
--- a/pkg/platform/controller/addon/ipam/ipam_controller.go
+++ b/pkg/platform/controller/addon/ipam/ipam_controller.go
@@ -631,8 +631,8 @@ func serviceIPAM() *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": "galaxy-ipam"},
 			Ports: []corev1.ServicePort{
-				{Name: "scheduler-port", Port: 9040, TargetPort: intstr.FromInt(9040), NodePort: 32760},
-				{Name: "api-port", Port: 9041, TargetPort: intstr.FromInt(9041), NodePort: 32761},
+				{Name: "scheduler-port", Port: 9040, TargetPort: intstr.FromInt(9040)},
+				{Name: "api-port", Port: 9041, TargetPort: intstr.FromInt(9041)},
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},


### PR DESCRIPTION
galaxy-ipam use ClusterIP service type in [#271]( https://github.com/tkestack/tke/pull/271)
There is bug that its service still use NodePort field.