### PR TITLE
docs: explanation for tokenPrivateKeyFile format

### DIFF
--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -444,6 +444,7 @@ previous step. For macOS, the path is usually /Users/${username}/Library/Applica
     fileSystem:
       rootDirectory: _debug/registry
   security:
+    # private key for signing registry JWT token, PKCS#1 encoded.
     tokenPrivateKeyFile: keys/private_key.pem
     tokenPublicKeyFile: keys/public.crt
     adminPassword: secret


### PR DESCRIPTION
With a certificate generated by `mkcert`, which is PKCS#8 formatted, we will get error:
```
Error: unable to decode private key PEM: unable to get PrivateKey from PEM type: PRIVATE KEY
```

Should we do necessary conversion silently or just improve the documentation?