### PR TITLE
fix(console): disable multiple namespace selection

### DIFF
--- a/web/console/Wrapper.tsx
+++ b/web/console/Wrapper.tsx
@@ -40,6 +40,9 @@ export enum ConsoleModuleEnum {
   /** 镜像仓库 */
   Registry = 'registry',
 
+  /** 日志模块 */
+  LogAgent = 'logagent',
+
   /** 认证模块 */
   Auth = 'auth',
 
@@ -149,7 +152,7 @@ const commonRouterConfig: RouterConfig[] = [
   },
   {
     title: '运维中心',
-    watchModule: [ConsoleModuleEnum.PLATFORM, ConsoleModuleEnum.Audit],
+    watchModule: [ConsoleModuleEnum.PLATFORM, ConsoleModuleEnum.Audit, ConsoleModuleEnum.LogAgent],
     subRouterConfig: [
       {
         url: '/tkestack/helm',
@@ -159,12 +162,12 @@ const commonRouterConfig: RouterConfig[] = [
       {
         url: '/tkestack/log',
         title: '日志采集',
-        watchModule: ConsoleModuleEnum.PLATFORM,
+        watchModule: ConsoleModuleEnum.LogAgent,
       },
       {
         url: '/tkestack/log/setting',
         title: '日志组件',
-        watchModule: ConsoleModuleEnum.PLATFORM,
+        watchModule: ConsoleModuleEnum.LogAgent,
       },
       {
         url: '/tkestack/persistent-event',
@@ -231,12 +234,12 @@ const businessCommonRouterConfig: RouterConfig[] = [
   },
   {
     title: '运维中心',
-    watchModule: [ConsoleModuleEnum.PLATFORM],
+    watchModule: [ConsoleModuleEnum.LogAgent],
     subRouterConfig: [
       {
         url: '/tkestack-project/log',
         title: '日志采集',
-        watchModule: ConsoleModuleEnum.PLATFORM
+        watchModule: ConsoleModuleEnum.LogAgent
       }
     ]
   },

--- a/web/console/config/resource/common/apiVersion.ts
+++ b/web/console/config/resource/common/apiVersion.ts
@@ -458,6 +458,7 @@ const k8sApiVersionFor18: ApiVersion = {
     group: logAgentServiceVersion.group,
     version: logAgentServiceVersion.version,
     basicEntry: logAgentServiceVersion.basicUrl,
+    watchModule: ConsoleModuleEnum.LogAgent,
     headTitle: 'LogAgent'
   },
   clustercredential: {

--- a/web/console/src/modules/cluster/WebAPI/K8sResourceAPI.ts
+++ b/web/console/src/modules/cluster/WebAPI/K8sResourceAPI.ts
@@ -519,7 +519,7 @@ export async function fetchResourceLogHierarchy(query: LogHierarchyQuery) {
 
   if (response.code === 0) {
     let content = response.data;
-    content !== '' && traverse(content);
+    !isEmpty(content) && traverse(content);
   }
 
   return logList;

--- a/web/console/src/modules/cluster/WebAPI/K8sResourceAPI.ts
+++ b/web/console/src/modules/cluster/WebAPI/K8sResourceAPI.ts
@@ -518,8 +518,11 @@ export async function fetchResourceLogHierarchy(query: LogHierarchyQuery) {
   };
 
   if (response.code === 0) {
-    let content = response.data;
-    !isEmpty(content) && traverse(content);
+    // 接口成功的话 response.data 为日志内容，失败的话为 { Code: '', Message: '' } 格式的错误
+    if (response.data && !response.data.Code) {
+      let content = response.data;
+      !isEmpty(content) && traverse(content);
+    }
   }
 
   return logList;
@@ -557,7 +560,9 @@ export async function fetchResourceLogContent(query: LogContentQuery) {
 
   if (response.code === 0) {
     let { data } = response;
-    content = data.content;
+    if (data && data.content) {
+      content = data.content;
+    }
   }
 
   return content;

--- a/web/console/src/modules/cluster/actions/clusterActions.ts
+++ b/web/console/src/modules/cluster/actions/clusterActions.ts
@@ -84,14 +84,16 @@ const FFModelClusterActions = createFFListActions<Cluster, ClusterFilter>({
     for (let record of response.records) {
       record.spec.hasPrometheus = clusterHasPs[record.metadata.name];
     }
-    // 增加获取日志采集组件信息
-    let agents = await CommonAPI.fetchLogagents();
-    let clusterHasLogAgent = {};
-    for (let agent of agents.records) {
-      clusterHasLogAgent[agent.spec.clusterName] = agent.metadata.name;
-    }
-    for (let cluster of response.records) {
-      cluster.spec.logAgentName = clusterHasLogAgent[cluster.metadata.name];
+    if (window['modules'] && window['modules']['logagent']) {
+      // 增加获取日志采集组件信息
+      let agents = await CommonAPI.fetchLogagents();
+      let clusterHasLogAgent = {};
+      for (let agent of agents.records) {
+        clusterHasLogAgent[agent.spec.clusterName] = agent.metadata.name;
+      }
+      for (let cluster of response.records) {
+        cluster.spec.logAgentName = clusterHasLogAgent[cluster.metadata.name];
+      }
     }
     return response;
   },

--- a/web/console/src/modules/cluster/actions/resourcePodLogActions.ts
+++ b/web/console/src/modules/cluster/actions/resourcePodLogActions.ts
@@ -82,18 +82,17 @@ const restActions = {
       if (urlParams['tab'] === 'log') {
         dispatch(resourcePodLogActions.handleFetchData(podName, containerName, tailLines));
         // 拉取日志目录结构
-        let agentName = '';
         if (logAgent && logAgent['metadata'] && logAgent['metadata']['name']) {
-          agentName = logAgent['metadata']['name'];
+          let agentName = logAgent['metadata']['name'];
+          const query: LogHierarchyQuery = {
+            agentName,
+            namespace: route.queries['np'],
+            clusterId: route.queries['clusterId'],
+            pod: podName,
+            container: containerName,
+          };
+          dispatch(resourcePodLogActions.getLogHierarchy(query));
         }
-        const query: LogHierarchyQuery = {
-          agentName,
-          namespace: route.queries['np'],
-          clusterId: route.queries['clusterId'],
-          pod: podName,
-          container: containerName,
-        };
-        dispatch(resourcePodLogActions.getLogHierarchy(query));
       }
     };
   },

--- a/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodLogPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodLogPanel.tsx
@@ -54,29 +54,31 @@ export class ResourcePodLogPanel extends React.Component<RootProps, {}> {
       { podName, containerName, logFile, tailLines } = subRoot.resourceDetailState.logOption;
     let clusterId = route.queries['clusterId'];
 
-    // 获取集群日志组件名称
-    let resourceInfo: ResourceInfo = resourceConfig()['logagent'];
-    let k8sQueryObj = {
-      fieldSelector: `spec.clusterName=${clusterId}`
-    };
+    if (window['modules'] && window['modules']['logagent']) {
+      // 获取集群日志组件名称
+      let resourceInfo: ResourceInfo = resourceConfig()['logagent'];
+      let k8sQueryObj = {
+        fieldSelector: `spec.clusterName=${clusterId}`
+      };
 
-    k8sQueryObj = JSON.parse(JSON.stringify(k8sQueryObj));
-    let logAgent = await WebAPI.fetchLogagentName(resourceInfo, clusterId, k8sQueryObj);
-    actions.resourceDetail.log.setLogAgent(logAgent);
+      k8sQueryObj = JSON.parse(JSON.stringify(k8sQueryObj));
+      let logAgent = await WebAPI.fetchLogagentName(resourceInfo, clusterId, k8sQueryObj);
+      actions.resourceDetail.log.setLogAgent(logAgent);
 
-    if (podName !== '' && containerName !== '') {
-      actions.resourceDetail.log.selectLogFile(logFile);
-      actions.resourceDetail.log.handleFetchData(podName, containerName, tailLines);
+      if (podName !== '' && containerName !== '') {
+        actions.resourceDetail.log.selectLogFile(logFile);
+        actions.resourceDetail.log.handleFetchData(podName, containerName, tailLines);
 
-      if (logAgent && logAgent['metadata'] && logAgent['metadata']['name']) {
-        let agentName = logAgent['metadata']['name'];
-        actions.resourceDetail.log.getLogHierarchy({
-          agentName,
-          clusterId: route.queries['clusterId'],
-          namespace: route.queries['np'],
-          container: containerName,
-          pod: podName
-        });
+        if (logAgent && logAgent['metadata'] && logAgent['metadata']['name']) {
+          let agentName = logAgent['metadata']['name'];
+          actions.resourceDetail.log.getLogHierarchy({
+            agentName,
+            clusterId: route.queries['clusterId'],
+            namespace: route.queries['np'],
+            container: containerName,
+            pod: podName
+          });
+        }
       }
     }
   }

--- a/web/console/src/modules/logStash/WebAPI.ts
+++ b/web/console/src/modules/logStash/WebAPI.ts
@@ -23,9 +23,10 @@ export async function checkStashNameIsExist(
 ) {
   let resourceInfo = resourceConfig(clusterVersion)['logcs'];
   let url = reduceK8sRestfulPath({
+    isSpetialNamespace: true,
     resourceInfo,
     clusterId,
-    namespace,
+    namespace: namespace.replace(new RegExp(`^${clusterId}-`), ''),
     specificName: logStashName
   });
   let params: RequestParams = {

--- a/web/console/src/modules/logStash/actions/clusterActions.ts
+++ b/web/console/src/modules/logStash/actions/clusterActions.ts
@@ -75,6 +75,7 @@ const fetchClusterActions = generateFetcherActionCreator({
     for (let cluster of response.records) {
       cluster.spec.logAgentName = clusterHasLogAgent[cluster.metadata.name];
     }
+
     return response;
   },
   finish: (dispatch: Redux.Dispatch, getState: GetState) => {

--- a/web/console/src/modules/logStash/components/EditLogStashPanel.tsx
+++ b/web/console/src/modules/logStash/components/EditLogStashPanel.tsx
@@ -310,7 +310,7 @@ export class EditLogStashPanel extends React.Component<RootProps, any> {
   }
 
   private async _handleSubmit(mode) {
-    let { actions, route, logStashEdit, isOpenLogStash, clusterVersion, logSelection, clusterSelection } = this.props;
+    let { actions, route, logStashEdit, clusterVersion, logSelection, clusterSelection } = this.props;
     let { rid, clusterId } = route.queries;
     let { logAgentName } = clusterSelection[0].spec;
     let {
@@ -352,7 +352,7 @@ export class EditLogStashPanel extends React.Component<RootProps, any> {
       +rid
     );
 
-    if (valResult && isOpenLogStash) {
+    if (valResult) {
       let { rid, clusterId } = route.queries;
 
       let logResourceInfo = resourceConfig(clusterVersion)['logcs'];

--- a/web/console/src/modules/logStash/components/EditOriginContainerItemPanel.tsx
+++ b/web/console/src/modules/logStash/components/EditOriginContainerItemPanel.tsx
@@ -69,6 +69,7 @@ export class EditOriginContainerItemPanel extends React.Component<ContainerItemP
     return (
       <FormPanel fixed isNeedCard={false} style={{ minWidth: 600, padding: '30px' }}>
         <div className="run-docker-box" style={containerLog.collectorWay === 'workload' ? { minWidth: '750px' } : {}}>
+          {window.location.href.includes('/tkestack-project') ||
           <div className="justify-grid">
             <div className="col">
               <span />
@@ -91,7 +92,7 @@ export class EditOriginContainerItemPanel extends React.Component<ContainerItemP
                 <i className="icon-cancel-icon" />
               </LinkButton>
             </div>
-          </div>
+          </div>}
           <div className="edit-param-list">
             <div className="param-box" style={{ paddingBottom: '0' }}>
               <div className="param-bd">

--- a/web/console/src/modules/logStash/components/EditOriginContainerPanel.tsx
+++ b/web/console/src/modules/logStash/components/EditOriginContainerPanel.tsx
@@ -88,7 +88,8 @@ export class EditOriginContainerPanel extends React.Component<RootProps, any> {
 
         {isSelectedAllNamespace === 'selectOne' && this._renderContainerLogList()}
 
-        {isSelectedAllNamespace === 'selectOne' && (
+        {window.location.href.includes('/tkestack-project') ||
+        isSelectedAllNamespace === 'selectOne' && (
           <Bubble content={!canAdd ? tip : null} placement="right">
             <a
               href="javascript:;"

--- a/web/console/src/modules/logStash/components/LogStashActionPanel.tsx
+++ b/web/console/src/modules/logStash/components/LogStashActionPanel.tsx
@@ -82,7 +82,7 @@ export class LogStashActionPanel extends React.Component<RootProps, any> {
     }
     // 判断当前是否能够新建日志收集规则
     let { canCreate, tip } = isCanCreateLogStash(clusterSelection[0], logList.data.records, isDaemonsetNormal);
-    let ifFetchLogList = includes(canFetchLogList, isDaemonsetNormal.phase);
+    let ifFetchLogList = logAgentName || includes(canFetchLogList, isDaemonsetNormal.phase);
     let handleNamespaceSwitched = namespaceSelection => {
       let namespaceFound = namespaceList.data.records.find(item => item.namespace === namespaceSelection);
       actions.cluster.selectClusterFromNamespace(namespaceFound.cluster);


### PR DESCRIPTION
1. Fix the checking of logHierarchy call response.
2. Trim clusterId from namespace when checking if the logStash rule name exists.
3. Disable multiple namespace selection of new logStash rule on the service side.
4. Refine the checking of if the logging add-on exists.
5. Add watching of logAgent module