### PR TITLE
fix(platform): update metric k8s_node_status_ready

### DIFF
--- a/pkg/platform/controller/addon/prometheus/yamls.go
+++ b/pkg/platform/controller/addon/prometheus/yamls.go
@@ -626,10 +626,10 @@ groups:
   - record: k8s_pod_restart_total
     expr: sum(idelta(kube_pod_container_status_restarts_total [2m])) by (namespace,pod_name) *  on(namespace, pod_name) group_left(workload_kind,workload_name,node, node_role)  __pod_info2
 
-  - record: k8s_node_status_ready
+  - record: k8s_node_status_ready_with_node_role
     expr: max(kube_node_status_condition{condition="Ready", status="true"} * on (node) group_left(node_role, device_type)  kube_node_labels)  without(condition, status)
 
-  - record: k8s_node_status_ready_without_node_role
+  - record: k8s_node_status_ready
     expr: max(kube_node_status_condition{condition="Ready", status="true"})  without(condition, status)
 
   - record: k8s_node_pod_restart_total


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
metric k8s_node_status_ready now group_left with kube_node_labels, which comes from each node. We cannot get kube_node_labels if a node is down, cause no data of k8s_node_status_ready for this node. Alarm depending on k8s_node_status_ready will fail.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

