### PR TITLE
fix: FromContext panic

### DIFF
--- a/pkg/platform/controller/cluster/cluster_controller.go
+++ b/pkg/platform/controller/cluster/cluster_controller.go
@@ -239,7 +239,7 @@ func (c *Controller) reconcile(ctx context.Context, key string, cluster *platfor
 		err = c.onUpdate(ctx, cluster)
 	case platformv1.ClusterTerminating:
 		log.FromContext(ctx).Info("Cluster has been terminated. Attempting to cleanup resources")
-		err = c.deleter.Delete(context.Background(), key)
+		err = c.deleter.Delete(ctx, key)
 		if err == nil {
 			log.FromContext(ctx).Info("Machine has been successfully deleted")
 		}

--- a/pkg/util/log/context.go
+++ b/pkg/util/log/context.go
@@ -35,5 +35,11 @@ func (l *zapLogger) WithContext(ctx context.Context) context.Context {
 
 // FromContext returns the value of the log key on the ctx.
 func FromContext(ctx context.Context) Logger {
-	return ctx.Value(logContextKey).(Logger)
+	if ctx != nil {
+		logger := ctx.Value(logContextKey)
+		if logger != nil {
+			return logger.(Logger)
+		}
+	}
+	return WithName("Unknown-Context")
 }


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Try to fix the panic when deleting cluster.
Some defensive codes are added to `log.FromContext` to avoid the same mistakes that call `log.FromContext` without setting the logger.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

![image](https://user-images.githubusercontent.com/9098726/86130494-cfe83e00-bb16-11ea-9487-78c3cb5bbf50.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

