### PR TITLE
fix(cluster): backport from 1.3 to fix ipam service ip and floating ip cm

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/manifests.go
+++ b/pkg/platform/provider/baremetal/cluster/manifests.go
@@ -53,7 +53,7 @@ const (
             }
          ],
          "nodeCacheCapable" : false,
-         "urlPrefix" : "http://galaxy-ipam:9040/v1"
+         "urlPrefix" : "http://{{.GalaxyIPAMHost}}:9040/v1"
       }
    ],
    "kind" : "Policy"

--- a/pkg/platform/provider/baremetal/constants/constants.go
+++ b/pkg/platform/provider/baremetal/constants/constants.go
@@ -81,5 +81,7 @@ const (
 
 	DNSIPIndex                   = 10
 	GPUQuotaAdmissionIPIndex     = 9
+	GalaxyIPAMIPIndex            = 8
 	GPUQuotaAdmissionIPAnnotaion = platformv1.GroupName + "/gpu-quota-admission-ip"
+	GalaxyIPAMIPIndexAnnotaion   = platformv1.GroupName + "/galaxy-ipam-ip"
 )


### PR DESCRIPTION

Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
backport from 1.3, try to fix:
1. kube-scheduler can not access galaxy-ipam by service name, change to service ip, and allocate service ip for ipam.
2. create an empty configmap for floating ip, otherwise ipam can not work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

