### PR TITLE
fix(console): create Import cluster address split error

### DIFF
--- a/web/console/src/modules/cluster/actions/validateClusterCreationAction.ts
+++ b/web/console/src/modules/cluster/actions/validateClusterCreationAction.ts
@@ -35,9 +35,6 @@ export const validateClusterCreationAction = {
     };
   },
 
-  /**
-   * 校验apiserver地址是否正确
-   */
   _validateApiServer(name: string) {
     let status = 0,
       message = '',
@@ -56,7 +53,9 @@ export const validateClusterCreationAction = {
       let path = '',
         port = '';
       if (host.indexOf('/') !== -1) {
-        path = host.substring(host.indexOf('/'));
+        let index = host.indexOf('/');
+        path = host.substring(index);
+        host = host.substring(0, index);
         port = '443';
       } else {
         port = tempSplit[1] ? tempSplit[1].split('/')[0] : '443';
@@ -91,6 +90,7 @@ export const validateClusterCreationAction = {
 
     return { status, message };
   },
+
   validateApiServer() {
     return async (dispatch: Redux.Dispatch, getState: GetState) => {
       let { apiServer } = getState().clusterCreationState;

--- a/web/console/src/modules/cluster/components/clusterManage/CreateClusterPanel.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/CreateClusterPanel.tsx
@@ -54,7 +54,9 @@ export class CreateClusterPanel extends React.Component<RootProps, {}> {
         let path = '',
           port = '';
         if (host.indexOf('/') !== -1) {
-          path = host.substring(host.indexOf('/'));
+          let index = host.indexOf('/');
+          path = host.substring(index);
+          host = host.substring(0, index);
           port = '443';
         } else {
           port = tempSplit[1] ? tempSplit[1].split('/')[0] : '443';
@@ -84,7 +86,7 @@ export class CreateClusterPanel extends React.Component<RootProps, {}> {
               {
                 host: host,
                 type: 'Advertise',
-                port: port,
+                port: +port,
                 path: path
               }
             ],


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

