### PR TITLE
fix(monitor): use prometheus client instead of k8s legacyregistry

### DIFF
--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -19,6 +19,7 @@
 package controller
 
 import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
 	componentconfig "k8s.io/component-base/config"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"net/http"
 	goruntime "runtime"
 )
@@ -61,7 +61,7 @@ func NewBaseHandler(c *componentconfig.DebuggingConfiguration, checks ...healthz
 			goruntime.SetBlockProfileRate(1)
 		}
 	}
-	m.Handle("/metrics", legacyregistry.Handler())
+	m.Handle("/metrics", promhttp.Handler())
 
 	return m
 }

--- a/pkg/monitor/storage/project/metrics.go
+++ b/pkg/monitor/storage/project/metrics.go
@@ -19,636 +19,84 @@
 package project
 
 import (
-	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	projectMetricsMap = map[string]*metrics.GaugeVec{}
-	projectMetrics    = []*metrics.GaugeVec{
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cpu",
-				Help:           "Project capacity of cpu.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_memory",
-				Help:           "Project capacity of memory.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_configmaps",
-				Help:           "Project capacity of configmaps.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_ephemeral_storage",
-				Help:           "Project capacity of ephemeral storage.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_persistentvolumeclaims",
-				Help:           "Project capacity of persistentvolumeclaims.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_pods",
-				Help:           "Project capacity of pods.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_resourcequotas",
-				Help:           "Project capacity of resourcequotas.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_secrets",
-				Help:           "Project capacity of secrets.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_services",
-				Help:           "Project capacity of services.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_services_loadbalancers",
-				Help:           "Project capacity of services.loadbalancers.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_services_nodeports",
-				Help:           "Project capacity of services.nodeports.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_cpu",
-				Help:           "Sum of cluster capacity of cpu for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_memory",
-				Help:           "Sum of cluster capacity of memory for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_configmaps",
-				Help:           "Sum of cluster capacity of configmaps for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_ephemeral_storage",
-				Help:           "Sum of cluster capacity of ephemeral storage for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_persistentvolumeclaims",
-				Help:           "Sum of cluster capacity of persistentvolumeclaims for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_pods",
-				Help:           "Sum of cluster capacity of pods for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_resourcequotas",
-				Help:           "Sum of cluster capacity of resourcequotas for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_secrets",
-				Help:           "Sum of cluster capacity of secrets for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_services",
-				Help:           "Sum of cluster capacity of services for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_services_loadbalancers",
-				Help:           "Sum of cluster capacity of services loadbalancers for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_capacity_cluster_services_nodeports",
-				Help:           "Sum of cluster capacity of services nodeports for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_cpu",
-				Help:           "Cpu allocated to pods for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_memory",
-				Help:           "Memory allocated to pods for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_configmaps",
-				Help:           "Configmaps allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_ephemeral_storage",
-				Help:           "Ephemeral-storage allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_persistentvolumeclaims",
-				Help:           "Persistentvolumeclaims allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_pods",
-				Help:           "Pods allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_resourcequotas",
-				Help:           "Resourcequotas allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_secrets",
-				Help:           "Secrets allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_services",
-				Help:           "Services allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_services_loadbalancers",
-				Help:           "Services loadbalancers allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_allocated_services_nodeports",
-				Help:           "Services nodeports allocated for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_cpu",
-				Help:           "Cpu capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_memory",
-				Help:           "Memory capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_configmaps",
-				Help:           "Configmaps capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_ephemeral_storage",
-				Help:           "Ephemeral-storage capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_persistentvolumeclaims",
-				Help:           "Persistentvolumeclaims capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_pods",
-				Help:           "Pods capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_resourcequotas",
-				Help:           "Resourcequotas capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_secrets",
-				Help:           "Secrets capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_services",
-				Help:           "Services capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_services_loadbalancers",
-				Help:           "Services loadbalancers capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_capacity_services_nodeports",
-				Help:           "Services nodeports capacity of namespaces of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_cpu",
-				Help:           "Cpu allocated to pods of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_memory",
-				Help:           "Memory allocated to pods of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_configmaps",
-				Help:           "Configmaps allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_ephemeral_storage",
-				Help:           "Ephemeral-storage allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_persistentvolumeclaims",
-				Help:           "Persistentvolumeclaims allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_pods",
-				Help:           "Pods allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_resourcequotas",
-				Help:           "Resourcequotas allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_secrets",
-				Help:           "Secrets allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_services",
-				Help:           "Services allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_services_loadbalancers",
-				Help:           "Services loadbalancers allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_cluster_allocated_services_nodeports",
-				Help:           "Services nodeports allocated of each cluster for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_cpu",
-				Help:           "Cpu capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_memory",
-				Help:           "Memory capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_configmaps",
-				Help:           "Configmaps capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_ephemeral_storage",
-				Help:           "Ephemeral-storage capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_persistentvolumeclaims",
-				Help:           "Persistentvolumeclaims capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_pods",
-				Help:           "Pods capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_resourcequotas",
-				Help:           "Resourcequotas capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_secrets",
-				Help:           "Secrets capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_services",
-				Help:           "Services capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_services_loadbalancers",
-				Help:           "Services loadbalancers capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_capacity_services_nodeports",
-				Help:           "Services nodeports capacity of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_cpu",
-				Help:           "Cpu allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_memory",
-				Help:           "Memory allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_configmaps",
-				Help:           "Configmaps allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_ephemeral_storage",
-				Help:           "Ephemeral-storage allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_persistentvolumeclaims",
-				Help:           "Persistentvolumeclaims allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_pods",
-				Help:           "Pods allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_resourcequotas",
-				Help:           "Resourcequotas allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_secrets",
-				Help:           "Secrets allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_services",
-				Help:           "Services allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_services_loadbalancers",
-				Help:           "Services loadbalancers allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
-		metrics.NewGaugeVec(
-			&metrics.GaugeOpts{
-				Name:           "project_namespace_allocated_services_nodeports",
-				Help:           "Services nodeports allocated of each namespace for each project.",
-				StabilityLevel: metrics.ALPHA,
-			},
-			[]string{"project_name", "cluster_name", "namespace", "namespace_name"},
-		),
+	projectMetricsMap = map[string]*prometheus.GaugeVec{}
+	resources         = []string{
+		"cpu",
+		"memory",
+		"configmaps",
+		"ephemeral_storage",
+		"persistentvolumeclaims",
+		"pods",
+		"resourcequotas",
+		"secrets",
+		"services",
+		"services_loadbalancers",
+		"services_nodeports",
 	}
 )
 
 func init() {
-	for _, metric := range projectMetrics {
-		legacyregistry.MustRegister(metric)
-		projectMetricsMap[metric.Name] = metric
+	for _, resource := range resources {
+		prefix := "project_capacity"
+		name := fmt.Sprintf("%s_%s", prefix, resource)
+		help := fmt.Sprintf("Project capacity of %s", resource)
+		labelNames := []string{"project_name"}
+		metric := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_capacity_cluster"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("Sum of cluster capacity of %s for each project.", resource)
+		labelNames = []string{"project_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_allocated"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("%s allocated for each project.", resource)
+		labelNames = []string{"project_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_cluster_capacity"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("%s capacity of namespaces of each cluster for each project.", resource)
+		labelNames = []string{"project_name", "cluster_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_cluster_allocated"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("%s allocated of each cluster for each project.", resource)
+		labelNames = []string{"project_name", "cluster_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_namespace_capacity"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("%s capacity of each namespace for each project.", resource)
+		labelNames = []string{"project_name", "cluster_name", "namespace", "namespace_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
+
+		prefix = "project_namespace_allocated"
+		name = fmt.Sprintf("%s_%s", prefix, resource)
+		help = fmt.Sprintf("%s allocated of each namespace for each project.", resource)
+		labelNames = []string{"project_name", "cluster_name", "namespace", "namespace_name"}
+		metric = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: name, Help: help}, labelNames)
+		prometheus.MustRegister(metric)
+		projectMetricsMap[name] = metric
 	}
 }


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In former commit (1b8a822e8660cbbacf14e5956c2166e14c64e3f9) tke-monitor-controller uses k8s.io/component-base/metrics/legacyregistry instead of github.com/prometheus/client_golang/prometheus/promhttp to provide metrics.
This causes other metrics like rate_limiter_use of all controllers fail to expose.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

