### PR TITLE
fix(notify): fix wrong notifyAddress stored in tke-notify-api cm

### DIFF
--- a/cmd/tke-notify-api/app/server.go
+++ b/cmd/tke-notify-api/app/server.go
@@ -48,7 +48,7 @@ func CreateServerChain(cfg *config.Config) (*genericapiserver.GenericAPIServer, 
 		cfg.VersionedSharedInformerFactory.Start(ctx.StopCh)
 
 		// Store notify api address in configmap named tke-notify-api; It is used by prometheus addon for alertmanager to send alarms
-		notifyAPIAddress := fmt.Sprintf("https://%s:%d", cfg.ExternalHost, cfg.ExternalPort)
+		notifyAPIAddress := fmt.Sprintf("https://%s.tke:%d", cfg.ExternalHost, cfg.ExternalPort)
 		notifyConfigMap := &v1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: v1.GroupName + "/" + v1.Version,
@@ -61,8 +61,8 @@ func CreateServerChain(cfg *config.Config) (*genericapiserver.GenericAPIServer, 
 		}
 		cm, err := cfg.PlatformClient.ConfigMaps().Get(context.Background(), NotifyApiConfigMapName, metav1.GetOptions{})
 		if err == nil && cm != nil {
-			v, ok := cm.Annotations[NotifyAPIAddressKey]
-			if !ok || v != notifyConfigMap.Annotations[NotifyAPIAddressKey] {
+			_, ok := cm.Annotations[NotifyAPIAddressKey]
+			if !ok {
 				notifyConfigMap.ResourceVersion = cm.ResourceVersion
 				_, err = cfg.PlatformClient.ConfigMaps().Update(context.Background(), notifyConfigMap, metav1.UpdateOptions{})
 				if err != nil {


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
notifyAddress stored in tke-notify-api configmap is wrong
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

