### PR TITLE
fix(prometheus): add metric prometheus_status_fail to expose status o…

### DIFF
--- a/pkg/monitor/controller/prometheus/controller.go
+++ b/pkg/monitor/controller/prometheus/controller.go
@@ -520,6 +520,7 @@ func (c *Controller) createPrometheusIfNeeded(ctx context.Context, key string, c
 		}
 	case v1.AddonPhaseRunning:
 		log.Info("Prometheus entry Running", log.String("prome", key))
+		UpdateMetricPrometheusStatusFail(prometheus.Spec.TenantID, prometheus.Spec.ClusterName, false)
 		if needUpgrade(prometheus) {
 			c.health.Delete(key)
 			prometheus = prometheus.DeepCopy()
@@ -547,6 +548,8 @@ func (c *Controller) createPrometheusIfNeeded(ctx context.Context, key string, c
 		log.Info("Prometheus entry fail", log.String("prome", key))
 		c.upgrading.Delete(key)
 		c.health.Delete(key)
+
+		UpdateMetricPrometheusStatusFail(prometheus.Spec.TenantID, prometheus.Spec.ClusterName, true)
 
 		// should try check when prometheus recover again
 		log.Info("Prometheus try checking after fail", log.String("prome", key))

--- a/pkg/monitor/controller/prometheus/metrics.go
+++ b/pkg/monitor/controller/prometheus/metrics.go
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package prometheus
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	prometheusStatusFail = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prometheus_status_fail",
+			Help: "prometheus addon status fail or not",
+		},
+		[]string{"tenant_id", "cluster_name"})
+)
+
+func init() {
+	prometheus.MustRegister(prometheusStatusFail)
+}
+
+func UpdateMetricPrometheusStatusFail(tenantID string, clusterName string, failed bool) {
+	labels := map[string]string{"tenant_id": tenantID, "cluster_name": clusterName}
+	if failed {
+		prometheusStatusFail.With(labels).Set(1)
+	} else {
+		prometheusStatusFail.With(labels).Set(0)
+	}
+}

--- a/pkg/platform/controller/addon/prometheus/controller.go
+++ b/pkg/platform/controller/addon/prometheus/controller.go
@@ -516,6 +516,7 @@ func (c *Controller) createPrometheusIfNeeded(ctx context.Context, key string, c
 		}
 	case v1.AddonPhaseRunning:
 		log.Info("Prometheus entry Running", log.String("prome", key))
+		UpdateMetricPrometheusStatusFail(prometheus.Spec.TenantID, prometheus.Spec.ClusterName, false)
 		if needUpgrade(prometheus) {
 			c.health.Delete(key)
 			prometheus = prometheus.DeepCopy()
@@ -543,6 +544,8 @@ func (c *Controller) createPrometheusIfNeeded(ctx context.Context, key string, c
 		log.Info("Prometheus entry fail", log.String("prome", key))
 		c.upgrading.Delete(key)
 		c.health.Delete(key)
+
+		UpdateMetricPrometheusStatusFail(prometheus.Spec.TenantID, prometheus.Spec.ClusterName, true)
 
 		// should try check when prometheus recover again
 		log.Info("Prometheus try checking after fail", log.String("prome", key))

--- a/pkg/platform/controller/addon/prometheus/metrics.go
+++ b/pkg/platform/controller/addon/prometheus/metrics.go
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package prometheus
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	prometheusStatusFail = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prometheus_status_fail",
+			Help: "prometheus addon status fail or not",
+		},
+		[]string{"tenant_id", "cluster_name"})
+)
+
+func init() {
+	prometheus.MustRegister(prometheusStatusFail)
+}
+
+func UpdateMetricPrometheusStatusFail(tenantID string, clusterName string, failed bool) {
+	labels := map[string]string{"tenantID": tenantID, "clusterName": clusterName}
+	if failed {
+		prometheusStatusFail.With(labels).Set(1)
+	} else {
+		prometheusStatusFail.With(labels).Set(0)
+	}
+}


### PR DESCRIPTION
…f prometheus

Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
add metric prometheus_status_fail to expose status of prometheus, as we can monitor proemtheus status on global cluster
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

