### PR TITLE
fix(prometheus): fix wrong label name of metric prometheus_status_fail

### DIFF
--- a/pkg/platform/controller/addon/prometheus/metrics.go
+++ b/pkg/platform/controller/addon/prometheus/metrics.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func UpdateMetricPrometheusStatusFail(tenantID string, clusterName string, failed bool) {
-	labels := map[string]string{"tenantID": tenantID, "clusterName": clusterName}
+	labels := map[string]string{"tenant_id": tenantID, "cluster_name": clusterName}
 	if failed {
 		prometheusStatusFail.With(labels).Set(1)
 	} else {


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
code setting labels of prometheus_status_fail using wrong names
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

