### PR TITLE
fix(installer): use standard function to parse docker image name

### DIFF
--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -27,6 +27,7 @@ import (
 
 	"tkestack.io/tke/pkg/spec"
 
+	"github.com/docker/distribution/reference"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -154,14 +155,20 @@ func (d *Docker) GetNameArchTag(image string) (name string, arch string, tag str
 // SplitImageNameAndTag returns the name & tag of the given image.
 // If the tag is <none>, return err.
 func (d *Docker) SplitImageNameAndTag(image string) (name string, tag string, err error) {
-	nameAndTag := strings.Split(image, ":")
-	if len(nameAndTag) != 2 {
+	imageRef, err := reference.Parse(image)
+	if err != nil {
 		return "", "", fmt.Errorf("fail to get name and tag for image: %v", image)
 	}
-	if nameAndTag[1] == "<none>" {
-		return "", "", fmt.Errorf("image %s is invalid", image)
+
+	switch v := imageRef.(type) {
+	case reference.NamedTagged:
+		if v.Tag() == "<none>" {
+			return "", "", fmt.Errorf("image %s is invalid", image)
+		}
+		return v.Name(), v.Tag(), nil
+	default:
+		return "", "", fmt.Errorf("image: %v does not have a name and tag", image)
 	}
-	return nameAndTag[0], nameAndTag[1], nil
 }
 
 // SplitNameAndArch returns the real name & arch of the given name.

--- a/pkg/util/docker/docker_test.go
+++ b/pkg/util/docker/docker_test.go
@@ -1,0 +1,119 @@
+package docker
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestDockerGetNameArchTag(t *testing.T) {
+	imageTestCases := []struct {
+		// image is the image name component of testcase
+		image string
+		// name is the string representation for the image name (without arch)
+		name string
+		// arch is the arch info for the image name
+		arch string
+		// tag is the tag for the image name
+		tag string
+		// err is the error expected from Parse, or nil
+		err error
+	}{
+		{
+			image: "localhost:5000/library/test-amd64:v1.2.3",
+			name:  "localhost:5000/library/test",
+			arch:  "amd64",
+			tag:   "v1.2.3",
+			err:   nil,
+		},
+		{
+			image: "127.0.0.1/tke/test-aaa:1.2.3",
+			name:  "127.0.0.1/tke/test-aaa",
+			arch:  "",
+			tag:   "1.2.3",
+			err:   nil,
+		},
+		{
+			image: "tke/test-arm64:1-2-3",
+			name:  "tke/test",
+			arch:  "arm64",
+			tag:   "1-2-3",
+			err:   nil,
+		},
+		{
+			image: "test-aaa:1.2.3-amd64",
+			name:  "test-aaa",
+			arch:  "",
+			tag:   "1.2.3-amd64",
+			err:   nil,
+		},
+		{
+			image: "test:5000/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			name:  "",
+			arch:  "",
+			tag:   "",
+			err:   fmt.Errorf("image: %v does not have a name and tag", "test:5000/repo@sha256:ffff"),
+		},
+		{
+			image: "tketest:<none>",
+			name:  "",
+			arch:  "",
+			tag:   "",
+			err:   fmt.Errorf("image %s is invalid", "tketest:<none>"),
+		},
+		{
+			image: "tketest",
+			name:  "",
+			arch:  "",
+			tag:   "",
+			err:   fmt.Errorf("image: %v does not have a name and tag", "tketest"),
+		},
+		{
+			image: "tketest/test/test",
+			name:  "",
+			arch:  "",
+			tag:   "",
+			err:   fmt.Errorf("image: %v does not have a name and tag", "tketest"),
+		},
+		{
+			image: "tketest/test1/test2/test3:v1.23",
+			name:  "tketest/test1/test2/test3",
+			arch:  "",
+			tag:   "v1.23",
+			err:   nil,
+		},
+	}
+
+	docker := New()
+	for _, testcase := range imageTestCases {
+		failf := func(format string, v ...interface{}) {
+			t.Logf(strconv.Quote(testcase.image)+": "+format, v...)
+			t.Fail()
+		}
+
+		name, arch, tag, err := docker.GetNameArchTag(testcase.image)
+		if testcase.err != nil {
+			if err == nil {
+				failf("missing expected error: %v", testcase.err)
+			}
+		}
+
+		if testcase.err == nil {
+			if err != nil {
+				failf("unexpected error: %v", err)
+			}
+		}
+
+		if name != testcase.name {
+			failf("mismatched name: got %q, expected %q", name, testcase.name)
+		}
+
+		if arch != testcase.arch {
+			failf("mismatched arch: got %q, expected %q", arch, testcase.arch)
+		}
+
+		if tag != testcase.tag {
+			failf("mismatched tag: got %q, expected %q", tag, testcase.tag)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
> Fix the problem of parsing docker images.
> Before fixing: installer cannot parse image name like `localhost:5000/library/test-amd64:v1.2.3` correctly

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
Add test cases.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

