### PR TITLE
fix(cluster): remove ipam service nodePort

### DIFF
--- a/pkg/platform/controller/addon/ipam/ipam_controller.go
+++ b/pkg/platform/controller/addon/ipam/ipam_controller.go
@@ -659,8 +659,8 @@ func serviceIPAM(clusterIP string) *corev1.Service {
 			ClusterIP: clusterIP,
 			Selector:  map[string]string{"app": "galaxy-ipam"},
 			Ports: []corev1.ServicePort{
-				{Name: "scheduler-port", Port: 9040, TargetPort: intstr.FromInt(9040), NodePort: 32760},
-				{Name: "api-port", Port: 9041, TargetPort: intstr.FromInt(9041), NodePort: 32761},
+				{Name: "scheduler-port", Port: 9040, TargetPort: intstr.FromInt(9040)},
+				{Name: "api-port", Port: 9041, TargetPort: intstr.FromInt(9041)},
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

Cannot create `ipam` service with nodePort, remove nodePort, backport from release-1.3

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

