### PR TITLE
fix(cluster): remove CronHPA when deleting cluster

### DIFF
--- a/pkg/platform/controller/addon/cronhpa/controller.go
+++ b/pkg/platform/controller/addon/cronhpa/controller.go
@@ -512,6 +512,11 @@ func (c *Controller) uninstallCronHPA(cronHPA *v1.CronHPA) error {
 	if err != nil {
 		return err
 	}
+	if cluster.Status.Phase == v1.ClusterTerminating {
+		log.Info(fmt.Sprintf("Keep the components of CronHPA %s when deleting the cluster", cronHPA.Spec.ClusterName))
+		return nil
+	}
+
 	kubeClient, err := util.BuildExternalClientSet(cluster, c.client.PlatformV1())
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Delete `CronHPA` addon when deleting cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

