### PR TITLE
fix(monitor): fix metric conflict in monitor prometheus controller

### DIFF
--- a/pkg/monitor/controller/prometheus/metrics.go
+++ b/pkg/monitor/controller/prometheus/metrics.go
@@ -21,9 +21,10 @@ package prometheus
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	//TODO switch name back to prometheus_status_fail when rm platform addon platform
 	prometheusStatusFail = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "prometheus_status_fail",
+			Name: "prometheus_status_fail_monitor",
 			Help: "prometheus addon status fail or not",
 		},
 		[]string{"tenant_id", "cluster_name", "prometheus_name"})


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
metric adding in commit ef0b6698acabac52c1779ecb8fe2d32f247d5118 causes conflict between prometheus controlled by monitor and platform. As prometheus switch to monitor is working in progress, change the name for now until the transition is complete.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

