### PR TITLE
feat(platform): add metrics-server to cluster feature

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/create.go
+++ b/pkg/platform/provider/baremetal/cluster/create.go
@@ -1049,6 +1049,24 @@ func (p *Provider) EnsureGPUManager(ctx context.Context, c *v1.Cluster) error {
 	return nil
 }
 
+func (p *Provider) EnsureMetricsServer(ctx context.Context, c *v1.Cluster) error {
+	client, err := c.Clientset()
+	if err != nil {
+		return err
+	}
+	option := map[string]interface{}{
+		"MetricsServerImage": images.Get().MetricsServer.FullName(),
+		"AddonResizerImage":  images.Get().AddonResizer.FullName(),
+	}
+
+	err = apiclient.CreateResourceWithFile(ctx, client, constants.MetricsServerManifest, option)
+	if err != nil {
+		return errors.Wrap(err, "install metrics server error")
+	}
+
+	return nil
+}
+
 func (p *Provider) EnsureCSIOperator(ctx context.Context, c *v1.Cluster) error {
 	if c.Cluster.Spec.Features.CSIOperator == nil {
 		return nil

--- a/pkg/platform/provider/baremetal/cluster/provider.go
+++ b/pkg/platform/provider/baremetal/cluster/provider.go
@@ -122,6 +122,7 @@ func NewProvider() (*Provider, error) {
 			p.EnsureNvidiaDevicePlugin,
 			p.EnsureGPUManager,
 			p.EnsureCSIOperator,
+			p.EnsureMetricsServer,
 
 			p.EnsureCleanup,
 			p.EnsureCreateClusterMark,

--- a/pkg/platform/provider/baremetal/constants/constants.go
+++ b/pkg/platform/provider/baremetal/constants/constants.go
@@ -109,6 +109,7 @@ const (
 	ManifestsDir          = ProviderDir + "manifests/"
 	GPUManagerManifest    = ManifestsDir + "gpu-manager/gpu-manager.yaml"
 	CSIOperatorManifest   = ManifestsDir + "csi-operator/csi-operator.yaml"
+	MetricsServerManifest = ManifestsDir + "metrics-server/metrics-server.yaml"
 
 	KUBERNETES                   = 1
 	DNSIPIndex                   = 10

--- a/pkg/platform/provider/baremetal/images/images.go
+++ b/pkg/platform/provider/baremetal/images/images.go
@@ -34,6 +34,9 @@ type Components struct {
 	GPUManager        containerregistry.Image
 	Busybox           containerregistry.Image
 	GPUQuotaAdmission containerregistry.Image
+
+	MetricsServer containerregistry.Image
+	AddonResizer  containerregistry.Image
 }
 
 func (c Components) Get(name string) *containerregistry.Image {
@@ -58,6 +61,9 @@ var components = Components{
 	GPUManager:        containerregistry.Image{Name: "gpu-manager", Tag: "v1.0.4"},
 	Busybox:           containerregistry.Image{Name: "busybox", Tag: "1.31.0"},
 	GPUQuotaAdmission: containerregistry.Image{Name: "gpu-quota-admission", Tag: "v1.0.0"},
+
+	MetricsServer: containerregistry.Image{Name: "metrics-server", Tag: "v0.3.6"},
+	AddonResizer:  containerregistry.Image{Name: "addon-resizer", Tag: "1.8.11"},
 }
 
 func List() []string {

--- a/pkg/platform/provider/baremetal/manifests/metrics-server/metrics-server.yaml
+++ b/pkg/platform/provider/baremetal/manifests/metrics-server/metrics-server.yaml
@@ -1,0 +1,235 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: https
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server-v0.3.6
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    version: v0.3.6
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+      version: v0.3.6
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+        version: v0.3.6
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - name: metrics-server
+        image: {{ .MetricsServerImage }}
+        command:
+        - /metrics-server
+        - --metric-resolution=30s
+        - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
+        - --requestheader-allowed-names=front-proxy-client
+        - --requestheader-extra-headers-prefix=X-Remote-Extra-
+        - --requestheader-group-headers=X-Remote-Group
+        - --requestheader-username-headers=X-Remote-User
+        - --kubelet-insecure-tls=true
+        - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
+        volumeMounts:
+        - name: etc-kubernetes-pki
+          mountPath: /etc/kubernetes/pki/
+          readOnly: true
+      - name: metrics-server-nanny
+        image: {{ .AddonResizerImage }}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 5m
+            memory: 50Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        volumeMounts:
+        - name: metrics-server-config-volume
+          mountPath: /etc/config
+        command:
+          - /pod_nanny
+          - --config-dir=/etc/config
+          - --cpu=80m
+          - --extra-cpu=0.5m
+          - --memory=80Mi
+          - --extra-memory=8Mi
+          - --threshold=5
+          - --deployment=metrics-server-v0.3.6
+          - --container=metrics-server
+          - --poll-period=300000
+          - --estimator=exponential
+          # Specifies the smallest cluster (defined in number of nodes)
+          # resources will be scaled to.
+          - --minClusterSize=3
+          # Use kube-apiserver metrics to avoid periodically listing nodes.
+          - --use-metrics=true
+      volumes:
+        - name: metrics-server-config-volume
+          configMap:
+            name: metrics-server-config
+        - name: etc-kubernetes-pki
+          hostPath:
+            path: /etc/kubernetes/pki/
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**

> /kind feature


**What this PR does / why we need it**:
Deploy metrics server for new clusters, providing metrics for other functions like HPA.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add metrics-server to cluster feature
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

