### PR TITLE
Revert "fix(cluster): query credentials and be compatible with older clusters"

### DIFF
--- a/pkg/platform/types/types.go
+++ b/pkg/platform/types/types.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/client-go/rest"
 	"tkestack.io/tke/api/client/clientset/internalversion/typed/platform/internalversion"
 	"tkestack.io/tke/api/platform"
-	"tkestack.io/tke/pkg/platform/util"
-	"tkestack.io/tke/pkg/util/log"
 )
 
 const (
@@ -71,12 +69,6 @@ func GetCluster(ctx context.Context, platformClient internalversion.PlatformInte
 			return nil, fmt.Errorf("get cluster's credential error: %w", err)
 		}
 		result.ClusterCredential = clusterCredential
-	} else {
-		credential, err := util.GetClusterCredential(ctx, platformClient, cluster)
-		if err != nil {
-			log.Errorf("query older cluster's credential error: %w", err)
-		}
-		result.ClusterCredential = credential
 	}
 
 	return result, nil


### PR DESCRIPTION
Reverts tkestack/tke#616