### PR TITLE
Platform fix

### DIFF
--- a/api/platform/cluster.go
+++ b/api/platform/cluster.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"path"
 	"time"
 
 	"tkestack.io/tke/pkg/util/ssh"
@@ -61,8 +62,12 @@ func (in *Cluster) Host() (string, error) {
 	if address == nil {
 		return "", errors.New("can't find valid address")
 	}
-
-	return fmt.Sprintf("%s:%d", address.Host, address.Port), nil
+	result := fmt.Sprintf("%s:%d", address.Host, address.Port)
+	if address.Path != "" {
+		result = path.Join(result, path.Clean(address.Path))
+		result = fmt.Sprintf("https://%s", result)
+	}
+	return result, nil
 }
 
 func (in *Cluster) AuthzWebhookEnabled() bool {

--- a/pkg/platform/types/v1/types.go
+++ b/pkg/platform/types/v1/types.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"path"
 	"time"
 
 	"github.com/pkg/errors"
@@ -187,8 +188,13 @@ func (c *Cluster) Host() (string, error) {
 	if address == nil {
 		return "", errors.New("can't find valid address")
 	}
+	result := fmt.Sprintf("%s:%d", address.Host, address.Port)
+	if address.Path != "" {
+		result = path.Join(result, path.Clean(address.Path))
+		result = fmt.Sprintf("https://%s", result)
+	}
 
-	return fmt.Sprintf("%s:%d", address.Host, address.Port), nil
+	return result, nil
 }
 
 func (c *Cluster) HostForBootstrap() (string, error) {

--- a/pkg/platform/util/client.go
+++ b/pkg/platform/util/client.go
@@ -178,7 +178,7 @@ func GetExternalRestConfig(cluster *platformv1.Cluster, credential *platformv1.C
 		Cluster:  contextName,
 		AuthInfo: contextName,
 	}
-	clientConfig := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{Timeout: "5s"}, nil)
+	clientConfig := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{Timeout: "30s"}, nil)
 	return clientConfig.ClientConfig()
 }
 
@@ -220,7 +220,7 @@ func GetInternalRestConfig(cluster *platform.Cluster, credential *platform.Clust
 		Cluster:  contextName,
 		AuthInfo: contextName,
 	}
-	clientConfig := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{Timeout: "5s"}, nil)
+	clientConfig := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{Timeout: "30s"}, nil)
 	return clientConfig.ClientConfig()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
1) 5s client timeout is too small for certain busy cluster
2) When cluster address.path is set, it should be add to host url after host:port pair

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

