### PR TITLE
fix(prometheus): fix k8s 1.16 cannot install prometheus

### DIFF
--- a/pkg/monitor/controller/prometheus/controller.go
+++ b/pkg/monitor/controller/prometheus/controller.go
@@ -639,7 +639,7 @@ func (c *Controller) installPrometheus(ctx context.Context, prometheus *v1.Prome
 
 	crds := getCRDs()
 	for _, crd := range crds {
-		if apiclient.ClusterVersionIsBefore117(kubeClient) {
+		if apiclient.ClusterVersionIsBefore116(kubeClient) {
 			crdObj := apiextensionsv1beta1.CustomResourceDefinition{}
 			err := json.Unmarshal([]byte(crd), &crdObj)
 			if err != nil {
@@ -2336,7 +2336,7 @@ func (c *Controller) uninstallPrometheus(ctx context.Context, prometheus *v1.Pro
 
 	crds := getCRDs()
 	for _, crd := range crds {
-		if apiclient.ClusterVersionIsBefore117(kubeClient) {
+		if apiclient.ClusterVersionIsBefore116(kubeClient) {
 			crdObj := apiextensionsv1beta1.CustomResourceDefinition{}
 			err := json.Unmarshal([]byte(crd), &crdObj)
 			if err != nil {

--- a/pkg/platform/controller/addon/prometheus/controller.go
+++ b/pkg/platform/controller/addon/prometheus/controller.go
@@ -631,7 +631,7 @@ func (c *Controller) installPrometheus(ctx context.Context, prometheus *v1.Prome
 
 	crds := getCRDs()
 	for _, crd := range crds {
-		if apiclient.ClusterVersionIsBefore117(kubeClient) {
+		if apiclient.ClusterVersionIsBefore116(kubeClient) {
 			crdObj := apiextensionsv1beta1.CustomResourceDefinition{}
 			err := json.Unmarshal([]byte(crd), &crdObj)
 			if err != nil {
@@ -2327,7 +2327,7 @@ func (c *Controller) uninstallPrometheus(ctx context.Context, prometheus *v1.Pro
 
 	crds := getCRDs()
 	for _, crd := range crds {
-		if apiclient.ClusterVersionIsBefore117(kubeClient) {
+		if apiclient.ClusterVersionIsBefore116(kubeClient) {
 			crdObj := apiextensionsv1beta1.CustomResourceDefinition{}
 			err := json.Unmarshal([]byte(crd), &crdObj)
 			if err != nil {

--- a/pkg/util/apiclient/version.go
+++ b/pkg/util/apiclient/version.go
@@ -35,8 +35,8 @@ func ClusterVersionIsBefore19(client kubernetes.Interface) bool {
 	return result
 }
 
-func ClusterVersionIsBefore117(client kubernetes.Interface) bool {
-	result, err := CheckClusterVersion(client, "< 1.17")
+func ClusterVersionIsBefore116(client kubernetes.Interface) bool {
+	result, err := CheckClusterVersion(client, "< 1.16")
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
k8s 1.16 deprecates apiextensions.k8s.io/v1beta1,  use apiextensions.k8s.io/v1 instead
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

