### PR TITLE
fix(cluster): update kubelet version compare

### DIFF
--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -408,7 +409,18 @@ func needUpgradeNode(client kubernetes.Interface, nodeName string, version strin
 	if err != nil {
 		return false, err
 	}
-	if strings.HasSuffix(node.Status.NodeInfo.KubeletVersion, version) {
+	nodeVersion, err := semver.NewVersion(node.Status.NodeInfo.KubeletVersion)
+	if err != nil {
+		return false, err
+	}
+	needVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	if nodeVersion.Major() == needVersion.Major() &&
+		nodeVersion.Minor() == needVersion.Minor() &&
+		nodeVersion.Patch() == needVersion.Patch() {
 		return false, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Support to compare kubelet versions with pre-release version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

