### PR TITLE
fix(installer): mark status as retrying rather failed when a step failed

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -942,7 +942,7 @@ func (t *TKE) do() {
 			start := time.Now()
 			err := t.steps[t.Step].Func(ctx)
 			if err != nil {
-				t.progress.Status = types.StatusFailed
+				t.progress.Status = types.StatusRetrying
 				t.log.Errorf("%d.%s [Failed] [%fs] error %s", t.Step, t.steps[t.Step].Name, time.Since(start).Seconds(), err)
 				return false, nil
 			}
@@ -950,7 +950,7 @@ func (t *TKE) do() {
 
 			t.Step++
 			t.backup()
-
+			t.progress.Status = types.StatusDoing
 			return true, nil
 		})
 	}

--- a/cmd/tke-installer/app/installer/types/types.go
+++ b/cmd/tke-installer/app/installer/types/types.go
@@ -207,10 +207,11 @@ type ClusterProgress struct {
 type ClusterProgressStatus string
 
 const (
-	StatusUnknown = "Unknown"
-	StatusDoing   = "Doing"
-	StatusSuccess = "Success"
-	StatusFailed  = "Failed"
+	StatusUnknown  = "Unknown"
+	StatusDoing    = "Doing"
+	StatusSuccess  = "Success"
+	StatusFailed   = "Failed"
+	StatusRetrying = "Retrying"
 )
 
 type Handler struct {


### PR DESCRIPTION
After introducing infinite retry, ClusterProgress.Status should be marked as 'retrying', otherwise response of /api/cluster/global/progress will be confusing