### PR TITLE
feat(platform): support customize flannel backend type

### DIFF
--- a/api/platform/v1/types.go
+++ b/api/platform/v1/types.go
@@ -87,6 +87,8 @@ type ClusterSpec struct {
 	// +optional
 	NetworkType NetworkType `json:"networkType,omitempty" protobuf:"bytes,6,opt,name=networkType,casttype=NetworkType"`
 	// +optional
+	NetworkArgs map[string]string `json:"networkArgs,omitempty" protobuf:"bytes,23,name=networkArgs"`
+	// +optional
 	NetworkDevice string `json:"networkDevice,omitempty" protobuf:"bytes,7,opt,name=networkDevice"`
 	// +optional
 	ClusterCIDR string `json:"clusterCIDR,omitempty" protobuf:"bytes,8,opt,name=clusterCIDR"`

--- a/pkg/platform/provider/baremetal/cluster/create.go
+++ b/pkg/platform/provider/baremetal/cluster/create.go
@@ -765,10 +765,19 @@ func (p *Provider) EnsureGalaxy(ctx context.Context, c *v1.Cluster) error {
 	if err != nil {
 		return err
 	}
+	backendType := "vxlan"
+	clusterSpec := c.Cluster.Spec
+	if clusterSpec.NetworkArgs != nil {
+		backendTypeArg, ok := clusterSpec.NetworkArgs["backendType"]
+		if ok {
+			backendType = backendTypeArg
+		}
+	}
 	return galaxy.Install(ctx, clientset, &galaxy.Option{
-		Version:   galaxyimages.LatestVersion,
-		NodeCIDR:  c.Cluster.Spec.ClusterCIDR,
-		NetDevice: c.Cluster.Spec.NetworkDevice,
+		Version:     galaxyimages.LatestVersion,
+		NodeCIDR:    clusterSpec.ClusterCIDR,
+		NetDevice:   clusterSpec.NetworkDevice,
+		BackendType: backendType,
 	})
 }
 

--- a/pkg/platform/provider/baremetal/phases/galaxy/template.go
+++ b/pkg/platform/provider/baremetal/phases/galaxy/template.go
@@ -253,7 +253,7 @@ data:
     {
       "Network": "{{ .Network }}",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "{{ .Type }}"
       }
     }
 `


### PR DESCRIPTION
Currently flannel backend type is hardcoded in tke source as `vxlan` , this PR enables passing `vxlan` or `host-gw` through ClusterSpec.NetworkType field.