### PR TITLE
fix(cluster): update kubelet version compare

### DIFF
--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -337,7 +338,11 @@ func UpgradeNode(s ssh.Interface, client kubernetes.Interface, platformClient pl
 		if err != nil {
 			return false, nil
 		}
-		if strings.HasSuffix(node.Status.NodeInfo.KubeletVersion, option.Version) {
+		same, err := sameVersion(node.Status.NodeInfo.KubeletVersion, option.Version)
+		if err != nil {
+			return false, nil
+		}
+		if same {
 			return true, err
 		}
 		return false, nil
@@ -408,11 +413,12 @@ func needUpgradeNode(client kubernetes.Interface, nodeName string, version strin
 	if err != nil {
 		return false, err
 	}
-	if strings.HasSuffix(node.Status.NodeInfo.KubeletVersion, version) {
-		return false, nil
-	}
 
-	return true, nil
+	same, err := sameVersion(node.Status.NodeInfo.KubeletVersion, version)
+	if err != nil {
+		return false, err
+	}
+	return !same, nil
 }
 
 // checkMasterNodesVersion check all master nodes version.
@@ -424,7 +430,11 @@ func checkMasterNodesVersion(client kubernetes.Interface, version string) (bool,
 		return false, err
 	}
 	for _, node := range nodes.Items {
-		if !strings.HasSuffix(node.Status.NodeInfo.KubeletVersion, version) {
+		same, err := sameVersion(node.Status.NodeInfo.KubeletVersion, version)
+		if err != nil {
+			return false, err
+		}
+		if !same {
 			return false, fmt.Errorf("master node(%s) current version is %s, required version is %s", node.Name, node.Status.NodeInfo.KubeletVersion, version)
 		}
 	}
@@ -522,8 +532,13 @@ func MarkNextUpgradeWorkerNode(client kubernetes.Interface, platformClient platf
 		if err != nil {
 			return err
 		}
+
+		same, err := sameVersion(node.Status.NodeInfo.KubeletVersion, version)
+		if err != nil {
+			return err
+		}
 		// Skip upgraded node.
-		if strings.HasSuffix(node.Status.NodeInfo.KubeletVersion, version) {
+		if same {
 			continue
 		}
 
@@ -547,4 +562,22 @@ func MarkNextUpgradeWorkerNode(client kubernetes.Interface, platformClient platf
 	}
 
 	return nil
+}
+
+func sameVersion(ver1, ver2 string) (bool, error) {
+	semVer1, err := semver.NewVersion(ver1)
+	if err != nil {
+		return false, err
+	}
+	semVer2, err := semver.NewVersion(ver2)
+	if err != nil {
+		return false, err
+	}
+
+	if semVer1.Major() == semVer2.Major() &&
+		semVer1.Minor() == semVer2.Minor() &&
+		semVer1.Patch() == semVer2.Patch() {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Support to compare kubelet versions with pre-release version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

