### PR TITLE
feat: write kubeconfig for current user

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -2272,6 +2272,7 @@ func (t *TKE) writeKubeconfig(ctx context.Context) error {
 		return err
 	}
 	_ = ioutil.WriteFile(constants.KubeconfigFile, data, 0644)
-	_ = os.MkdirAll("/root/.kube", 0755)
-	return ioutil.WriteFile("/root/.kube/config", data, 0644)
+	homeDir, _ := os.UserHomeDir()
+	_ = os.MkdirAll(homeDir+"/.kube", 0755)
+	return ioutil.WriteFile(homeDir+"/.kube/config", data, 0644)
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

write kubeconfig into home directory of current user rather /root.  with this PR, behavior of tke-installer won't change,  but friendly to development environment, no need to change file mode of /root
