### PR TITLE
feat(installer): generate image list for specified archs

### DIFF
--- a/cmd/generate-images/main.go
+++ b/cmd/generate-images/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/spf13/pflag"
 	"sort"
 	"strings"
 
@@ -44,6 +45,8 @@ var (
 )
 
 func main() {
+	archsFlag := pflag.StringSliceP("archs", "a", spec.Archs, "Only list images for specified archs")
+	pflag.Parse()
 	unsupportMultiArchImages := []func() []string{
 		cronhpa.List,
 		helm.List,
@@ -69,7 +72,7 @@ func main() {
 			if IsUnsupportMultiArch(one) {
 				result = append(result, one)
 			} else {
-				for _, arch := range spec.Archs {
+				for _, arch := range *archsFlag {
 					result = append(result, strings.ReplaceAll(one, ":", "-"+arch+":"))
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

Support generating image list for archs spefified by command line arg `--archs`, with this feature we can generate smaller tarball.
