### PR TITLE
fix(console): add sluster version compare in deployment rollback request

### DIFF
--- a/web/console/package-lock.json
+++ b/web/console/package-lock.json
@@ -2590,6 +2590,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npm.taobao.org/compare-versions/download/compare-versions-3.6.0.tgz",
+      "integrity": "sha1-GlaJkTaF5ah2N7jT/8p1UU7EHWI="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",

--- a/web/console/package.json
+++ b/web/console/package.json
@@ -30,6 +30,7 @@
     "@vx/shape": "0.0.181",
     "@vx/tooltip": "0.0.179",
     "array-move": "^2.1.0",
+    "compare-versions": "^3.6.0",
     "d3": "^5.9.2",
     "d3-scale": "^2.1.2",
     "d3-shape": "^1.2.2",

--- a/web/console/src/modules/cluster/components/resource/resourceDetail/ResourceRollbackDialog.tsx
+++ b/web/console/src/modules/cluster/components/resource/resourceDetail/ResourceRollbackDialog.tsx
@@ -16,7 +16,7 @@ const mapDispatchToProps = dispatch =>
 @connect(state => state, mapDispatchToProps)
 export class ResourceRollbackDialog extends React.Component<RootProps, {}> {
   render() {
-    let { actions, route, subRoot, region } = this.props,
+    let { actions, route, subRoot, region, clusterVersion } = this.props,
       { resourceInfo, resourceDetailState } = subRoot,
       { rollbackResourceFlow, rsSelection } = resourceDetailState;
 
@@ -40,7 +40,8 @@ export class ResourceRollbackDialog extends React.Component<RootProps, {}> {
       namespace: reduceNs(route.queries['np']),
       clusterId: route.queries['clusterId'],
       resourceIns,
-      jsonData: JSON.stringify(jsonData)
+      jsonData: JSON.stringify(jsonData),
+      clusterVersion
     };
 
     return (

--- a/web/console/src/modules/common/models/CreateResource.ts
+++ b/web/console/src/modules/common/models/CreateResource.ts
@@ -36,6 +36,9 @@ export interface CreateResource extends Identifiable {
   mergeType?: string;
 
   meshId?: string;
+
+  /** 集群版本 */
+  clusterVersion?: string;
 }
 
 export const MergeType = {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug

**What this PR does / why we need it**:
when cluster version >= 1.14, deployment rollback fail
**Which issue(s) this PR fixes**:
this pull request backend fix at there [https://github.com/tkestack/tke/pull/670](https://github.com/tkestack/tke/pull/670)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

