### PR TITLE
feat(gateway): support component openapi overview

### DIFF
--- a/pkg/gateway/proxy/handler/rewriteproxy/handler.go
+++ b/pkg/gateway/proxy/handler/rewriteproxy/handler.go
@@ -1,0 +1,97 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package rewriteproxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	gatewayconfig "tkestack.io/tke/pkg/gateway/apis/config"
+	"tkestack.io/tke/pkg/gateway/token"
+	"tkestack.io/tke/pkg/util/log"
+	"tkestack.io/tke/pkg/util/transport"
+)
+
+type handler struct {
+	reverseProxy    *httputil.ReverseProxy
+	protected       bool
+	rewritePathFunc RewritePathFunc
+}
+
+// RewritePathFunc rewrites url path.
+type RewritePathFunc func(path string) (newPath string)
+
+// NewHandler to create a reverse proxy handler and returns it.
+// The reverse proxy will rewrite url path .
+func NewHandler(address string, cfg *gatewayconfig.PassthroughComponent, protected bool, rewritePathFunc RewritePathFunc) (http.Handler, error) {
+	u, err := url.Parse(address)
+	if err != nil {
+		log.Error("Failed to parse backend service address", log.String("address", address), log.Err(err))
+		return nil, err
+	}
+
+	tr, err := transport.NewOneWayTLSTransport(cfg.CAFile, true)
+	if err != nil {
+		log.Error("Failed to create one-way HTTPS transport", log.String("caFile", cfg.CAFile), log.Err(err))
+		return nil, err
+	}
+
+	reverseProxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: u.Scheme, Host: u.Host})
+	reverseProxy.Transport = tr
+	reverseProxy.ErrorLog = log.StdErrLogger()
+	return &handler{reverseProxy, protected, rewritePathFunc}, nil
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	newPath := h.rewritePathFunc(req.URL.Path)
+	u, err := url.Parse(newPath)
+	if err != nil {
+		log.Error("Failed to parse new path", log.String("newPath", newPath), log.Err(err))
+		responsewriters.InternalError(w, req, err)
+	}
+	req.URL.Path = u.Path
+	if u.RawQuery != "" {
+		req.URL.RawQuery = u.RawQuery
+	}
+
+	if h.protected {
+		// read cookie
+		t, err := token.RetrieveToken(req)
+		if err != nil {
+			log.Error("Failed to retrieve token from client", log.Err(err))
+			responsewriters.WriteRawJSON(http.StatusUnauthorized, errors.NewUnauthorized(err.Error()), w)
+			return
+		}
+		log.Debug("Reverse proxy to protected backend component", log.String("url", req.URL.Path))
+		newReq := req.WithContext(context.Background())
+		newReq.Header = netutil.CloneHeader(req.Header)
+		newReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", strings.TrimSpace(t.ID)))
+		h.reverseProxy.ServeHTTP(w, newReq)
+		return
+	}
+	log.Debug("Reverse proxy to unprotected backend component", log.String("url", req.URL.Path))
+	h.reverseProxy.ServeHTTP(w, req)
+}

--- a/pkg/gateway/proxy/proxy.go
+++ b/pkg/gateway/proxy/proxy.go
@@ -34,13 +34,18 @@ import (
 	gatewayconfig "tkestack.io/tke/pkg/gateway/apis/config"
 	"tkestack.io/tke/pkg/gateway/proxy/handler/frontproxy"
 	"tkestack.io/tke/pkg/gateway/proxy/handler/passthrough"
+	"tkestack.io/tke/pkg/gateway/proxy/handler/rewriteproxy"
 	platformapiserver "tkestack.io/tke/pkg/platform/apiserver"
 	"tkestack.io/tke/pkg/registry/chartmuseum"
 	"tkestack.io/tke/pkg/registry/distribution"
 	"tkestack.io/tke/pkg/util/log"
 )
 
-const apiPrefix = "/apis"
+const (
+	apiPrefix      = "/apis"
+	openapiPrefix  = "/openapi"
+	openapiVersion = "v2"
+)
 
 type moduleName string
 
@@ -181,6 +186,22 @@ func RegisterRoute(m *mux.PathRecorderMux, cfg *gatewayconfig.GatewayConfigurati
 			m.HandlePrefix(pathPrefix.prefix, handler)
 		}
 	}
+	pathOpenapi := openapiProxy(cfg)
+	for path, proxyComponent := range pathOpenapi {
+		if proxyComponent.Passthrough != nil {
+			handler, err := rewriteproxy.NewHandler(
+				proxyComponent.Address,
+				proxyComponent.Passthrough,
+				path.protected,
+				func(string) string { return fmt.Sprintf("%s/%s", openapiPrefix, openapiVersion) },
+			)
+			if err != nil {
+				return err
+			}
+			log.Info("Registered openapi proxy for backend component", log.String("path", path.prefix), log.Bool("protected", path.protected), log.String("address", proxyComponent.Address))
+			m.Handle(path.prefix, handler)
+		}
+	}
 	return nil
 }
 
@@ -252,4 +273,47 @@ func prefixProxy(cfg *gatewayconfig.GatewayConfiguration) map[modulePath]gateway
 		}
 	}
 	return pathPrefixProxyMap
+}
+
+func openapiProxy(cfg *gatewayconfig.GatewayConfiguration) map[modulePath]gatewayconfig.Component {
+	newOpenapiPath := func(name moduleName) modulePath {
+		return modulePath{
+			prefix:    fmt.Sprintf("/tke-%s-api", name),
+			protected: false,
+		}
+	}
+	openapiProxyMap := make(map[modulePath]gatewayconfig.Component)
+	// platform
+	if cfg.Components.Platform != nil {
+		openapiProxyMap[newOpenapiPath(moduleNamePlatform)] = *cfg.Components.Platform
+	}
+	// business
+	if cfg.Components.Business != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameBusiness)] = *cfg.Components.Business
+	}
+	// notify
+	if cfg.Components.Notify != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameNotify)] = *cfg.Components.Notify
+	}
+	// monitor
+	if cfg.Components.Monitor != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameMonitor)] = *cfg.Components.Monitor
+	}
+	// auth
+	if cfg.Components.Auth != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameAuth)] = *cfg.Components.Auth
+	}
+	// registry
+	if cfg.Components.Registry != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameRegistry)] = *cfg.Components.Registry
+	}
+	// logagent
+	if cfg.Components.LogAgent != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameLogagent)] = *cfg.Components.LogAgent
+	}
+	// audit
+	if cfg.Components.Audit != nil {
+		openapiProxyMap[newOpenapiPath(moduleNameAudit)] = *cfg.Components.Audit
+	}
+	return openapiProxyMap
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR makes it's possible to overview component openapi through tke-gateway.

Available components:

- platform(/tke-platform-api)
- business(/tke-business-api)
- notify(/tke-notify-api)
- monitor(/tke-monitor-api)
- auth(/tke-auth-api)
- registry(/tke-registry-api)
- logagent(/tke-logagent-api)



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

