### PR TITLE
fix(platform,monitor): add missing labels for kubelet metrics 

### DIFF
--- a/pkg/monitor/controller/prometheus/yamls.go
+++ b/pkg/monitor/controller/prometheus/yamls.go
@@ -680,6 +680,9 @@ groups:
   - record: k8s_node_status_ready
     expr: max(kube_node_status_condition{condition="Ready", status="true"})  without(condition, status)
 
+  - record: k8s_node_not_ready
+    expr: max(kube_node_status_condition{condition="Ready", status="false"})  without(condition, status)
+
   - record: k8s_node_pod_restart_total
     expr: sum(k8s_pod_restart_total) without (pod_name,workload_kind,workload_name,namespace) * on(node) group_left(device_type) kube_node_labels
 

--- a/pkg/monitor/controller/prometheus/yamls.go
+++ b/pkg/monitor/controller/prometheus/yamls.go
@@ -1162,7 +1162,7 @@ groups:
     expr: sum(rate(apiserver_request_duration_seconds_sum{verb!="WATCH"}[5m])) by (node) * 1000000 / sum(rate(apiserver_request_duration_seconds_count{verb!="WATCH"}[5m])) by (node)
 
   - record: k8s_component_scheduler_scheduling_latency
-    expr: sum(scheduler_e2e_scheduling_latency_microseconds_sum) by (node) / sum(scheduler_e2e_scheduling_latency_microseconds_count) by (node)
+    expr: sum(scheduler_e2e_scheduling_duration_seconds_sum) by (node) *1000000 / sum(scheduler_e2e_scheduling_duration_seconds_count) by (node)
 
   - record: k8s_component_apiserver_version
     expr: max(kubernetes_build_info{pod_name=~"kube-apiserver.*"}) by (buildDate, compiler, gitCommit, gitTreeState, gitVersion, goVersion, major, minor, platform)

--- a/pkg/monitor/controller/prometheus/yamls.go
+++ b/pkg/monitor/controller/prometheus/yamls.go
@@ -42,9 +42,9 @@ func scrapeConfigForPrometheus() string {
         target_label: device_type
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-        regex: 'kubelet_running_pod_count|kubelet_volume_stats_used_bytes|kubelet_volume_stats_capacity_bytes|kubelet_pleg_relist_duration_seconds_sum|kubelet_pleg_relist_duration_seconds_count|kubelet_docker_operations_errors|kubelet_docker_operations_errors_total|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_pod_start_duration_seconds_(.*)|kubelet_pod_worker_duration_seconds_(.*)|storage_operation_duration_seconds_(.*)|storage_operation_errors_total|kubelet_runtime_operations_duration_seconds_(.*)|kubelet_cgroup_manager_duration_seconds_(.*)|go_goroutines|process_resident_memory_bytes|process_cpu_seconds_total|rest_client_requests_total|rest_client_request_latency_seconds_(.*)'
+        regex: 'kubelet_running_pod_count|kubelet_volume_stats_used_bytes|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_pleg_relist_duration_seconds_sum|kubelet_pleg_relist_duration_seconds_count|kubelet_docker_operations_errors|kubelet_docker_operations_errors_total|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_pod_start_duration_seconds_(.*)|kubelet_pod_worker_duration_seconds_(.*)|storage_operation_duration_seconds_(.*)|storage_operation_errors_total|kubelet_runtime_operations_duration_seconds_(.*)|kubelet_cgroup_manager_duration_seconds_(.*)|go_goroutines|process_resident_memory_bytes|process_cpu_seconds_total|rest_client_requests_total|rest_client_request_latency_seconds_(.*)'
         action: keep
-      - regex: (__name__|instance|node_role_kubernetes_io_master|device_type)
+      - regex: (__name__|instance|node_role_kubernetes_io_master|device_type|state|namespace|persistentvolumeclaim|operation_type|container_state|plugin_name|operation_name|volume_plugin)
         action: labelkeep
       - source_labels: [ __name__ ]
         target_label: "node_role"

--- a/pkg/platform/controller/addon/prometheus/yamls.go
+++ b/pkg/platform/controller/addon/prometheus/yamls.go
@@ -680,6 +680,9 @@ groups:
   - record: k8s_node_status_ready
     expr: max(kube_node_status_condition{condition="Ready", status="true"})  without(condition, status)
 
+  - record: k8s_node_not_ready
+    expr: max(kube_node_status_condition{condition="Ready", status="false"})  without(condition, status)
+
   - record: k8s_node_pod_restart_total
     expr: sum(k8s_pod_restart_total) without (pod_name,workload_kind,workload_name,namespace) * on(node) group_left(device_type) kube_node_labels
 

--- a/pkg/platform/controller/addon/prometheus/yamls.go
+++ b/pkg/platform/controller/addon/prometheus/yamls.go
@@ -1162,7 +1162,7 @@ groups:
     expr: sum(rate(apiserver_request_duration_seconds_sum{verb!="WATCH"}[5m])) by (node) * 1000000 / sum(rate(apiserver_request_duration_seconds_count{verb!="WATCH"}[5m])) by (node)
 
   - record: k8s_component_scheduler_scheduling_latency
-    expr: sum(scheduler_e2e_scheduling_latency_microseconds_sum) by (node) / sum(scheduler_e2e_scheduling_latency_microseconds_count) by (node)
+    expr: sum(scheduler_e2e_scheduling_duration_seconds_sum) by (node) *1000000 / sum(scheduler_e2e_scheduling_duration_seconds_count) by (node)
 
   - record: k8s_component_apiserver_version
     expr: max(kubernetes_build_info{pod_name=~"kube-apiserver.*"}) by (buildDate, compiler, gitCommit, gitTreeState, gitVersion, goVersion, major, minor, platform)

--- a/pkg/platform/controller/addon/prometheus/yamls.go
+++ b/pkg/platform/controller/addon/prometheus/yamls.go
@@ -42,9 +42,9 @@ func scrapeConfigForPrometheus() string {
         target_label: device_type
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-        regex: 'kubelet_running_pod_count|kubelet_volume_stats_used_bytes|kubelet_volume_stats_capacity_bytes|kubelet_pleg_relist_duration_seconds_sum|kubelet_pleg_relist_duration_seconds_count|kubelet_docker_operations_errors|kubelet_docker_operations_errors_total|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_pod_start_duration_seconds_(.*)|kubelet_pod_worker_duration_seconds_(.*)|storage_operation_duration_seconds_(.*)|storage_operation_errors_total|kubelet_runtime_operations_duration_seconds_(.*)|kubelet_cgroup_manager_duration_seconds_(.*)|go_goroutines|process_resident_memory_bytes|process_cpu_seconds_total|rest_client_requests_total|rest_client_request_latency_seconds_(.*)'
+        regex: 'kubelet_running_pod_count|kubelet_volume_stats_used_bytes|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_pleg_relist_duration_seconds_sum|kubelet_pleg_relist_duration_seconds_count|kubelet_docker_operations_errors|kubelet_docker_operations_errors_total|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_pod_start_duration_seconds_(.*)|kubelet_pod_worker_duration_seconds_(.*)|storage_operation_duration_seconds_(.*)|storage_operation_errors_total|kubelet_runtime_operations_duration_seconds_(.*)|kubelet_cgroup_manager_duration_seconds_(.*)|go_goroutines|process_resident_memory_bytes|process_cpu_seconds_total|rest_client_requests_total|rest_client_request_latency_seconds_(.*)'
         action: keep
-      - regex: (__name__|instance|node_role_kubernetes_io_master|device_type)
+      - regex: (__name__|instance|node_role_kubernetes_io_master|device_type|state|namespace|persistentvolumeclaim|operation_type|container_state|plugin_name|operation_name|volume_plugin)
         action: labelkeep
       - source_labels: [ __name__ ]
         target_label: "node_role"


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
add missing labels for kubelet metrics
fix scheduler latency metric for 1.18
add k8s_node_not_ready
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

