### PR TITLE
fix(installer): skip docker login when no username

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -695,7 +695,7 @@ func (t *TKE) validateConfig(config types.Config) *apierrors.StatusError {
 		return apierrors.NewBadRequest("tke registry or third party registry required")
 	}
 
-	if config.Registry.ThirdPartyRegistry != nil {
+	if config.Registry.ThirdPartyRegistry != nil && config.Registry.ThirdPartyRegistry.Username != "" {
 		cmd := exec.Command("docker", "login",
 			"--username", config.Registry.ThirdPartyRegistry.Username,
 			"--password", string(config.Registry.ThirdPartyRegistry.Password),

--- a/cmd/tke-installer/app/installer/types/types.go
+++ b/cmd/tke-installer/app/installer/types/types.go
@@ -118,8 +118,8 @@ type TKERegistry struct {
 type ThirdPartyRegistry struct {
 	Domain    string `json:"domain" validate:"required"`
 	Namespace string `json:"namespace" validate:"required"`
-	Username  string `json:"username" validate:"required"`
-	Password  []byte `json:"password" validate:"required"`
+	Username  string `json:"username"`
+	Password  []byte `json:"password"`
 }
 
 type Business struct {


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

