### PR TITLE
fix(auth): HA not work for auth webhook

### DIFF
--- a/api/platform/v1/cluster.go
+++ b/api/platform/v1/cluster.go
@@ -180,6 +180,18 @@ func (in *Cluster) AuthzWebhookBuiltinEndpoint() (string, bool) {
 		return "", false
 	}
 
-	return utilhttp.MakeEndpoint("https", in.Spec.Machines[0].IP,
+	endPointHost := in.Spec.Machines[0].IP
+
+	// use VIP in HA situation
+	if in.Spec.Features.HA != nil {
+		if in.Spec.Features.HA.TKEHA != nil {
+			endPointHost = in.Spec.Features.HA.TKEHA.VIP
+		}
+		if in.Spec.Features.HA.ThirdPartyHA != nil {
+			endPointHost = in.Spec.Features.HA.ThirdPartyHA.VIP
+		}
+	}
+
+	return utilhttp.MakeEndpoint("https", endPointHost,
 		constants.AuthzWebhookNodePort, "/auth/authz"), true
 }

--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1328,7 +1328,19 @@ func (t *TKE) prepareCertificates(ctx context.Context) error {
 }
 
 func (t *TKE) authzWebhookBuiltinEndpoint() string {
-	return utilhttp.MakeEndpoint("https", t.Para.Cluster.Spec.Machines[0].IP,
+	endPointHost := t.Para.Cluster.Spec.Machines[0].IP
+
+	// use VIP in HA situation
+	if t.Para.Cluster.Spec.Features.HA != nil {
+		if t.Para.Cluster.Spec.Features.HA.TKEHA != nil {
+			endPointHost = t.Para.Cluster.Spec.Features.HA.TKEHA.VIP
+		}
+		if t.Para.Cluster.Spec.Features.HA.ThirdPartyHA != nil {
+			endPointHost = t.Para.Cluster.Spec.Features.HA.ThirdPartyHA.VIP
+		}
+	}
+
+	return utilhttp.MakeEndpoint("https", endPointHost,
 		constants.AuthzWebhookNodePort, "/auth/authz")
 }
 

--- a/docs/guide/zh-CN/installation/installation-procedures.md
+++ b/docs/guide/zh-CN/installation/installation-procedures.md
@@ -56,7 +56,7 @@ arch=arm64 version=v1.3.1 && wget https://tke-release-1251707795.cos.ap-guangzho
      
      - **不设置**：第一台 master 节点的IP地址作为 APIServer 地址
      - **TKE提供**：用户只需提供可用的IP地址，TKE部署Keepalive，配置该IP为Master集群的VIP，以实现Global集群和控制台的高可用，此时该VIP和所有master节点IP地址都是APIserver地址。
-     - **使用已有**：对接配置好的外部 LB 实例，VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）端口，同时确保该VIP有至少两个LB后端（Master节点），以避免LB单后端不可用风险。
+     - **使用已有**：对接配置好的外部 LB 实例，VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）、31138（tke-auth-api端口）端口，同时确保该VIP有至少两个LB后端（Master节点），以避免LB单后端不可用风险。
 
 2. 填写 TKEStack 控制台集群设置信息
 

--- a/docs/guide/zh-CN/products/platform/cluster.md
+++ b/docs/guide/zh-CN/products/platform/cluster.md
@@ -37,7 +37,7 @@ TKEStack还可以另外**新建独立集群**以及**导入已有集群**实现*
 
   - **不使用**：第一台 master 节点的IP地址作为 APIServer 地址
   - **TKE提供**：用户只需提供可用的IP地址，TKE部署Keepalive，配置该IP为Master集群的VIP，以实现Global集群和控制台的高可用，此时该VIP和所有master节点IP地址都是APIserver地址。
-  - **使用已有**：对接配置好的外部 LB 实例，VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）端口，同时确保该VIP有至少两个LB后端（Master节点），以避免LB单后端不可用风险。
+  - **使用已有**：对接配置好的外部 LB 实例，VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）端口、31138（tke-auth-api端口），同时确保该VIP有至少两个LB后端（Master节点），以避免LB单后端不可用风险。
 
 + **GPU **：（按需使用，需要使用GPU可以勾选）
 

--- a/web/installer/src/modules/installer/components/Step2.tsx
+++ b/web/installer/src/modules/installer/components/Step2.tsx
@@ -108,7 +108,7 @@ export class Step2 extends React.Component<RootProps> {
                         <p>
                           <Text theme={'label'} reset>
                             <p>
-                              VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）端口，
+                              VIP绑定Master集群的80（tke控制台）、443（tke控制台）、6443（kube-apiserver端口）、31138（tke-auth-api端口）端口，
                             </p>
                             <p>同时确保该VIP有至少两个LB后端（Master节点），以避免LB单后端不可用风险</p>
                           </Text>


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Using NodePort as auth server will make HA not really work.
VIP + NodePort will resolve this issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

