### PR TITLE
fix(monitor): send alert to correct webhook addr

### DIFF
--- a/pkg/gateway/proxy/proxy.go
+++ b/pkg/gateway/proxy/proxy.go
@@ -78,10 +78,6 @@ func componentPrefix() map[moduleName][]modulePath {
 		},
 		moduleNameNotify: {
 			modulePath{
-				prefix:    "/webhook/",
-				protected: false,
-			},
-			modulePath{
 				prefix:    fmt.Sprintf("%s/%s/", apiPrefix, notify.GroupName),
 				protected: true,
 			},
@@ -209,6 +205,15 @@ func RegisterRoute(m *mux.PathRecorderMux, cfg *gatewayconfig.GatewayConfigurati
 			log.Info("Registered openapi proxy for backend component", log.String("path", path.prefix), log.Bool("protected", path.protected), log.String("address", proxyComponent.Address))
 			m.Handle(path.prefix, handler)
 		}
+	}
+	// proxy /webhook to tke-notify-api for alert
+	if cfg.Components.Notify.Passthrough != nil {
+		handler, err := passthrough.NewHandler(cfg.Components.Notify.Address, cfg.Components.Notify.Passthrough, false)
+		if err != nil {
+			return err
+		}
+		log.Info("Registered reverse proxy of passthrough mode for backend component", log.String("path", "/webhook"), log.Bool("protected", false), log.String("address", cfg.Components.Notify.Address))
+		m.Handle("/webhook", handler)
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Send alert to correct webhook addr through tke-gateway in non-global cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #758

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

