### PR TITLE
fix(platform): remove flag when renew certs

### DIFF
--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
@@ -151,7 +151,7 @@ func RenewCerts(s ssh.Interface) error {
 		return fmt.Errorf("fixKubeadmBug1753(https://github.com/kubernetes/kubeadm/issues/1753) error: %w", err)
 	}
 
-	cmd := fmt.Sprintf("kubeadm alpha certs renew all --config=%s", constants.KubeadmConfigFileName)
+	cmd := "kubeadm alpha certs renew all"
 	_, err = s.CombinedOutput(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If node join cluster through `kubeadm join`, InitConfiguration and clusterConfiguration is not in the host. Adding `--config` flag will case `no InitConfiguration or ClusterConfiguration kind was found in the YAML file` error.

If `--config` is not set, kubeadm will get InitConfiguration and clusterConfiguration from configmap when renew certs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

