### PR TITLE
ci(console): fix console part build faild, but ci not exit

### DIFF
--- a/build/docker/tke-gateway/build.sh
+++ b/build/docker/tke-gateway/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o xtrace
+set -e
 
 pwd
 

--- a/web/console/index.tsx
+++ b/web/console/index.tsx
@@ -82,7 +82,7 @@ interface ForbiddentDialogState {
 class ForbiddentDialog extends React.Component<any, ForbiddentDialogState> {
   constructor(props: any) {
     super(props);
-    state = {
+    this.state = {
       forbiddentConfig: Init_Forbiddent_Config
     };
 

--- a/web/console/index.tsx
+++ b/web/console/index.tsx
@@ -82,7 +82,7 @@ interface ForbiddentDialogState {
 class ForbiddentDialog extends React.Component<any, ForbiddentDialogState> {
   constructor(props: any) {
     super(props);
-    this.state = {
+    state = {
       forbiddentConfig: Init_Forbiddent_Config
     };
 

--- a/web/console/package.json
+++ b/web/console/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "common_pre": "rm -rf node_modules && npm i && npm run unzip_third_party",
-    "unzip_third_party": "unzip -n -d ./node_modules ../../third_party/fe_node_modules.zip",
+    "unzip_third_party": "unzip -n -q -d ./node_modules ../../third_party/fe_node_modules.zip",
     "predev": "npm run common_pre",
     "dev": "cross-env NODE_ENV=development Version=tke node ./develop/index.ts",
     "cp_public": "mkdir -p build && cp -r public/* build",

--- a/web/installer/package.json
+++ b/web/installer/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "common_pre": "rm -rf node_modules && npm i && npm run unzip_third_party",
-    "unzip_third_party": "unzip -n -d ./node_modules ../../third_party/fe_node_modules.zip",
+    "unzip_third_party": "unzip -n -q -d ./node_modules ../../third_party/fe_node_modules.zip",
     "predev": "npm run common_pre",
     "dev": "cross-env NODE_OPTIONS=--max_old_space_size=2048 NODE_ENV=development Version=tke node ./develop/index.ts",
     "cp_public": "mkdir -p build && cp -r public/* build",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
**What this PR does / why we need it**:
1、add set -e in build/docker/tke-gateway/build.sh;
2、add -q in package.json unzip, hide unused logs.

**Which issue(s) this PR fixes**:
https://github.com/tkestack/tke/issues/788
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

