### PR TITLE
fix(platform): allow user specify node name for cloud provider case

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/create.go
+++ b/pkg/platform/provider/baremetal/cluster/create.go
@@ -729,8 +729,11 @@ func (p *Provider) EnsureKubeadmInitPhaseKubeletStart(ctx context.Context, c *v1
 		return err
 	}
 	phase := "kubelet-start"
-	if !c.Spec.HostnameAsNodename {
-		phase += fmt.Sprintf(" --node-name=%s", c.Spec.Machines[0].IP)
+	kubeletExtraArgs := p.getKubeletExtraArgs(c)
+	if _, ok := kubeletExtraArgs["hostname-override"]; !ok {
+		if !c.Spec.HostnameAsNodename {
+			phase += fmt.Sprintf(" --node-name=%s", c.Spec.Machines[0].IP)
+		}
 	}
 	return kubeadm.Init(machineSSH, p.getKubeadmInitConfig(c), phase)
 }

--- a/pkg/platform/provider/baremetal/cluster/kubeadm.go
+++ b/pkg/platform/provider/baremetal/cluster/kubeadm.go
@@ -61,11 +61,12 @@ func (p *Provider) getKubeadmJoinConfig(c *v1.Cluster, machineIP string) *kubead
 	} else {
 		kubeletExtraArgs["node-labels"] = apiclient.GetNodeIPV6Label(machineIP)
 	}
-	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
-
-	if !c.Spec.HostnameAsNodename {
-		nodeRegistration.Name = machineIP
+	if _, ok := kubeletExtraArgs["hostname-override"]; !ok {
+		if !c.Spec.HostnameAsNodename {
+			nodeRegistration.Name = machineIP
+		}
 	}
+	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
 
 	return &kubeadmv1beta2.JoinConfiguration{
 		NodeRegistration: nodeRegistration,
@@ -99,11 +100,12 @@ func (p *Provider) getInitConfiguration(c *v1.Cluster) *kubeadmv1beta2.InitConfi
 	if _, ok := kubeletExtraArgs["node-ip"]; !ok {
 		kubeletExtraArgs["node-ip"] = machineIP
 	}
-	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
-
-	if !c.Spec.HostnameAsNodename {
-		nodeRegistration.Name = machineIP
+	if _, ok := kubeletExtraArgs["hostname-override"]; !ok {
+		if !c.Spec.HostnameAsNodename {
+			nodeRegistration.Name = machineIP
+		}
 	}
+	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
 
 	return &kubeadmv1beta2.InitConfiguration{
 		BootstrapTokens: []kubeadmv1beta2.BootstrapToken{

--- a/pkg/platform/provider/baremetal/machine/kubeadm.go
+++ b/pkg/platform/provider/baremetal/machine/kubeadm.go
@@ -48,11 +48,12 @@ func (p *Provider) getKubeadmJoinConfig(c *v1.Cluster, machineIP string) *kubead
 	if _, ok := kubeletExtraArgs["node-ip"]; !ok {
 		kubeletExtraArgs["node-ip"] = machineIP
 	}
-	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
-
-	if !c.Spec.HostnameAsNodename {
-		nodeRegistration.Name = machineIP
+	if _, ok := kubeletExtraArgs["hostname-override"]; !ok {
+		if !c.Spec.HostnameAsNodename {
+			nodeRegistration.Name = machineIP
+		}
 	}
+	nodeRegistration.KubeletExtraArgs = kubeletExtraArgs
 
 	return &kubeadmv1beta2.JoinConfiguration{
 		NodeRegistration: nodeRegistration,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/tkestack/tke/issues/745
Fixes  https://github.com/tkestack/tke/issues/770
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

