### PR TITLE
fix(console): kubeconfig api server path display error

### DIFF
--- a/web/console/src/modules/cluster/components/KubectlDialog.tsx
+++ b/web/console/src/modules/cluster/components/KubectlDialog.tsx
@@ -41,7 +41,7 @@ export class KubectlDialog extends React.Component<RootProps, any> {
       const address =
         clusterInfo.status.addresses.find(({ type }) => type === 'Advertise') || clusterInfo.status.addresses[0];
 
-      return `https://${address.host}:${address.port}/`;
+      return `https://${address.host}:${address.port}/${address.path}`;
     }
 
     const kubeconfig = getKubectlConfig({

--- a/web/console/src/modules/common/models/Cluster.ts
+++ b/web/console/src/modules/common/models/Cluster.ts
@@ -108,6 +108,8 @@ interface ClusterAddress {
   /** 端口名 */
   port: number;
 
+  path?: string;
+
   /** 集群的类型 */
   type: string;
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

