### PR TITLE
fix(platform): set owner reference leverage GC delete object

### DIFF
--- a/pkg/platform/controller/cluster/cluster_controller.go
+++ b/pkg/platform/controller/cluster/cluster_controller.go
@@ -344,7 +344,12 @@ func (c *Controller) ensureCreateClusterCredential(ctx context.Context, cluster 
 	credential := &platformv1.ClusterCredential{
 		TenantID:    cluster.Spec.TenantID,
 		ClusterName: cluster.Name,
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cluster, platformv1.SchemeGroupVersion.WithKind("Cluster"))},
+		},
 	}
+
 	credential, err = c.platformClient.ClusterCredentials().Create(ctx, credential, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/platform/controller/cluster/deletion/cluster_deleter.go
+++ b/pkg/platform/controller/cluster/deletion/cluster_deleter.go
@@ -246,7 +246,6 @@ var deleteResourceFuncs = []deleteResourceFunc{
 	deleteTappControllers,
 	deleteClusterProvider,
 	deleteMachine,
-	deleteClusterCredential,
 }
 
 // deleteAllContent will use the client to delete each resource identified in cluster.
@@ -405,6 +404,7 @@ func deleteClusterProvider(ctx context.Context, deleter *clusterDeleter, cluster
 	return nil
 }
 
+/*
 func deleteClusterCredential(ctx context.Context, deleter *clusterDeleter, cluster *platformv1.Cluster) error {
 	log.FromContext(ctx).Info("deleteClusterCredential doing")
 
@@ -433,6 +433,7 @@ func deleteClusterCredential(ctx context.Context, deleter *clusterDeleter, clust
 
 	return nil
 }
+*/
 
 func deleteMachine(ctx context.Context, deleter *clusterDeleter, cluster *platformv1.Cluster) error {
 	log.FromContext(ctx).Info("deleteMachine doing")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
fix https://github.com/tkestack/tke/issues/792

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

