### PR TITLE
fix(cluster): lost apiserver cert

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/provider.go
+++ b/pkg/platform/provider/baremetal/cluster/provider.go
@@ -133,8 +133,8 @@ func NewProvider() (*Provider, error) {
 		UpdateHandlers: []clusterprovider.Handler{
 			p.EnsureUpgradeControlPlaneNode,
 
-			p.EnsureRenewCerts,
 			p.EnsureAPIServerCert,
+			p.EnsureRenewCerts,
 			p.EnsureStoreCredential,
 			p.EnsureKeepalivedWithLB,
 			p.EnsureThirdPartyHA,

--- a/pkg/platform/provider/baremetal/cluster/update.go
+++ b/pkg/platform/provider/baremetal/cluster/update.go
@@ -94,7 +94,7 @@ func (p *Provider) EnsureAPIServerCert(ctx context.Context, c *v1.Cluster) error
 				actualCertSANs = append(actualCertSANs, ip.String())
 			}
 			if reflect.DeepEqual(funk.IntersectString(actualCertSANs, exptectCertSANs), exptectCertSANs) {
-				return nil
+				continue
 			}
 			log.FromContext(ctx).Info("EnsureAPIServerCert",
 				"nodeName", s.Host,
@@ -103,11 +103,12 @@ func (p *Provider) EnsureAPIServerCert(ctx context.Context, c *v1.Cluster) error
 			)
 		}
 
+		var preActions []string
 		for _, file := range []string{constants.APIServerCertName, constants.APIServerKeyName} {
-			s.CombinedOutput(fmt.Sprintf("rm -f %s", file))
+			preActions = append(preActions, fmt.Sprintf("rm -f %s", file))
 		}
 
-		err = kubeadm.Init(s, kubeadmConfig, "certs apiserver")
+		err = kubeadm.Init(s, kubeadmConfig, "certs apiserver", preActions...)
 		if err != nil {
 			return errors.Wrap(err, machine.IP)
 		}

--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
@@ -90,7 +90,7 @@ func Install(s ssh.Interface, version string) error {
 	return nil
 }
 
-func Init(s ssh.Interface, kubeadmConfig *InitConfig, phase string) error {
+func Init(s ssh.Interface, kubeadmConfig *InitConfig, phase string, preActions ...string) error {
 	configData, err := kubeadmConfig.Marshal()
 	if err != nil {
 		return err
@@ -107,7 +107,8 @@ func Init(s ssh.Interface, kubeadmConfig *InitConfig, phase string) error {
 	if err != nil {
 		return errors.Wrap(err, "parse initCmd error")
 	}
-	out, err := s.CombinedOutput(string(cmd))
+	actions := append(preActions, string(cmd))
+	out, err := s.CombinedOutput(strings.Join(actions, ";"))
 	if err != nil {
 		return fmt.Errorf("kubeadm.Init error: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

When ssh connection is not stable (for example when machine has just reboot), `EnsureAPIServerCert` may remove `apiserver.crt` and can not recover it by retry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

