### PR TITLE
fix(platform,monitor): use extension-apiserver-authentication cm

### DIFF
--- a/pkg/monitor/controller/prometheus/controller.go
+++ b/pkg/monitor/controller/prometheus/controller.go
@@ -2335,22 +2335,6 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: prometheusAdapterServiceAccount,
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{
-												Key:      "node-role.kubernetes.io/master",
-												Operator: corev1.NodeSelectorOpExists,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name:  prometheusAdapterWorkLoad,
@@ -2363,7 +2347,7 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 								"--v=3",
 								"--config=/etc/adapter/config.yaml",
 								"--cert-dir=/tmp",
-								"--requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt",
+								"--requestheader-client-ca-file=/etc/kubernetes/pki/requestheader-client-ca-file",
 								"--requestheader-allowed-names=front-proxy-client,admin",
 								"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 								"--requestheader-group-headers=X-Remote-Group",
@@ -2384,7 +2368,7 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 								},
 								{
 									MountPath: "/etc/kubernetes/pki/",
-									Name:      "etc-kubernetes-pki",
+									Name:      "extension-apiserver-authentication",
 									ReadOnly:  true,
 								},
 							},
@@ -2392,10 +2376,12 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "etc-kubernetes-pki",
+							Name: "extension-apiserver-authentication",
 							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/kubernetes/pki/",
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "extension-apiserver-authentication",
+									},
 								},
 							},
 						},

--- a/pkg/platform/controller/addon/prometheus/controller.go
+++ b/pkg/platform/controller/addon/prometheus/controller.go
@@ -2305,22 +2305,6 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: prometheusAdapterServiceAccount,
-					Affinity: &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-								NodeSelectorTerms: []corev1.NodeSelectorTerm{
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{
-												Key:      "node-role.kubernetes.io/master",
-												Operator: corev1.NodeSelectorOpExists,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name:  prometheusAdapterWorkLoad,
@@ -2333,7 +2317,7 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 								"--v=3",
 								"--config=/etc/adapter/config.yaml",
 								"--cert-dir=/tmp",
-								"--requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt",
+								"--requestheader-client-ca-file=/etc/kubernetes/pki/requestheader-client-ca-file",
 								"--requestheader-allowed-names=front-proxy-client,admin",
 								"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 								"--requestheader-group-headers=X-Remote-Group",
@@ -2354,7 +2338,7 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 								},
 								{
 									MountPath: "/etc/kubernetes/pki/",
-									Name:      "etc-kubernetes-pki",
+									Name:      "extension-apiserver-authentication",
 									ReadOnly:  true,
 								},
 							},
@@ -2362,10 +2346,12 @@ func createAppsDeploymentForPrometheusAdapter(components images.Components, prom
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "etc-kubernetes-pki",
+							Name: "extension-apiserver-authentication",
 							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/kubernetes/pki/",
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "extension-apiserver-authentication",
+									},
 								},
 							},
 						},

--- a/pkg/platform/provider/baremetal/manifests/metrics-server/metrics-server.yaml
+++ b/pkg/platform/provider/baremetal/manifests/metrics-server/metrics-server.yaml
@@ -162,20 +162,13 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
       containers:
       - name: metrics-server
         image: {{ .MetricsServerImage }}
         command:
         - /metrics-server
         - --metric-resolution=30s
-        - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
+        - --requestheader-client-ca-file=/etc/kubernetes/pki/requestheader-client-ca-file
         - --requestheader-allowed-names=front-proxy-client
         - --requestheader-extra-headers-prefix=X-Remote-Extra-
         - --requestheader-group-headers=X-Remote-Group
@@ -187,7 +180,7 @@ spec:
           name: https
           protocol: TCP
         volumeMounts:
-        - name: etc-kubernetes-pki
+        - name: extension-apiserver-authentication
           mountPath: /etc/kubernetes/pki/
           readOnly: true
       - name: metrics-server-nanny
@@ -232,9 +225,9 @@ spec:
         - name: metrics-server-config-volume
           configMap:
             name: metrics-server-config
-        - name: etc-kubernetes-pki
-          hostPath:
-            path: /etc/kubernetes/pki/
+        - configMap:
+            name: extension-apiserver-authentication
+          name: extension-apiserver-authentication
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"


### PR DESCRIPTION
instead of run on master node for metrics-server and prometheus
adapter

Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
We run mertics-server and prometheus-adapter on master since they need front-proxy-ca.crt, this ca file is stored in extension-apiserver-authentication configmap which we can use instead of master hostpath
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

