### PR TITLE
fix(cluster): check port

### DIFF
--- a/pkg/platform/provider/baremetal/preflight/checks.go
+++ b/pkg/platform/provider/baremetal/preflight/checks.go
@@ -213,7 +213,7 @@ func (poc PortOpenCheck) Name() string {
 func (poc PortOpenCheck) Check() (warnings, errorList []error) {
 
 	errorList = []error{}
-	stdout, _, exit, err := poc.Exec(fmt.Sprintf("ss -tl | grep ':%d'", poc.port))
+	stdout, _, exit, err := poc.Exec(fmt.Sprintf("ss -ntl | grep -w ':%d'", poc.port))
 	if err != nil {
 		errorList = append(errorList, err)
 		return


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR improved the port checking. The former implement without `-n` may miss some port, because `ss` will show port's name instead of number. The `-w` arg for `grep` tries to figure out different ports with the same prefix like `:80` and `:8080`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

