### PR TITLE
feat(console): add alarm node memory used

### DIFF
--- a/web/console/src/modules/alarmPolicy/constants/Config.ts
+++ b/web/console/src/modules/alarmPolicy/constants/Config.ts
@@ -355,6 +355,20 @@ export const AlarmPolicyMetrics = {
       tip: '',
       // metricType: 'event',
       unit: ''
+    },
+    {
+      enable: true,
+      measurement: 'k8s_node',
+      statisticsPeriod: 1,
+      metricName: 'k8s_node_filesystem_usage',
+      evaluatorType: 'gt',
+      evaluatorValue: '90',
+      metricDisplayName: t('节点磁盘已使用'),
+      continuePeriod: 5,
+      type: 'percent',
+      tip: '',
+      // metricType: 'metric',
+      unit: '%'
     }
   ],
   pod: [

--- a/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
@@ -19,6 +19,7 @@ export function ClusterUpdate({ route, actions }: RootProps) {
   };
 
   const { clusterId, clusterVersion } = route.queries;
+  const [_, clusterVersionSecondPart] = clusterVersion.split('.');
 
   function goBack() {
     history.back();
@@ -72,7 +73,17 @@ export function ClusterUpdate({ route, actions }: RootProps) {
           label="升级目标版本"
           extra="注意：master升级支持一个次版本升级到下一个次版本，或者同样次版本的补丁版。"
           name={['version']}
-          rules={[{ required: true }]}
+          rules={[
+            { required: true },
+            {
+              validator(_, value: string) {
+                const [__, targetSecond] = value.split('.');
+                return +targetSecond - +clusterVersionSecondPart === 1
+                  ? Promise.resolve()
+                  : Promise.reject('不支持直接升级到该版本！');
+              }
+            }
+          ]}
         >
           <Select style={ItemStyle()}>
             {k8sValidVersions.map(v => (


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind feature

**What this PR does / why we need it**:
1、node type alarm add memoru used item;
2、cluster update add rule only can upgrade version great one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

