### PR TITLE
fix(console): add cluster version is empty case

### DIFF
--- a/web/console/src/webApi/cluster.ts
+++ b/web/console/src/webApi/cluster.ts
@@ -38,6 +38,19 @@ export const checkClusterIsNeedUpdate = async ({
   clusterName: string;
   clusterVersion: string;
 }) => {
+  if (!clusterVersion) {
+    return {
+      master: {
+        isNeed: false,
+        message: '集群创建中！'
+      },
+
+      worker: {
+        isNeed: false,
+        message: '集群创建中！'
+      }
+    };
+  }
   // check machin
   const { items } = await Request.get<any, { items: Array<any> }>('/apis/platform.tkestack.io/v1/machines', {
     params: {

--- a/web/console/src/webApi/cluster.ts
+++ b/web/console/src/webApi/cluster.ts
@@ -38,6 +38,7 @@ export const checkClusterIsNeedUpdate = async ({
   clusterName: string;
   clusterVersion: string;
 }) => {
+  // 如果version不存在，说明集群在创建中
   if (!clusterVersion) {
     return {
       master: {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug

**What this PR does / why we need it**:
when cluster version is empty, cluster list load fail

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

