### PR TITLE
fix(platform): set gpu-manager and gpu-quota-admission log to stderr

### DIFF
--- a/pkg/platform/provider/baremetal/manifests/gpu-manager/gpu-manager.yaml
+++ b/pkg/platform/provider/baremetal/manifests/gpu-manager/gpu-manager.yaml
@@ -97,7 +97,7 @@ spec:
             - name: LOG_LEVEL
               value: "3"
             - name: EXTRA_FLAGS
-              value: "--incluster-mode=true"
+              value: "--incluster-mode=true --logtostderr"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -203,7 +203,7 @@ spec:
               - name: LOG_LEVEL
                 value: "4"
               - name: EXTRA_FLAGS
-                value: "--incluster-mode=true"
+                value: "--incluster-mode=true --logtostderr"
             ports:
               - containerPort: 3456
             volumeMounts:


### PR DESCRIPTION
Signed-off-by: Tengfei Wang <tfwang@alauda.io>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

