### PR TITLE
fix(console): 1.5.0-alpha bug fix 2020-12-02

### DIFF
--- a/web/console/src/modules/cluster/components/clusterManage/ClusterTablePanel.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/ClusterTablePanel.tsx
@@ -137,6 +137,25 @@ export class ClusterTablePanel extends React.Component<RootProps, State> {
             <Text theme={ClusterStatus[x.status.phase]} verticalAlign="middle">
               {x.status.phase || '-'}
             </Text>
+            {x.spec.updateInfo.worker.message === '有节点正在升级中' && (
+              <>
+                <Icon className="tea-ml-1n" type="loading" />{' '}
+                <Button
+                  type="link"
+                  onClick={() => {
+                    router.navigate(
+                      { sub: 'sub', mode: 'list', type: 'nodeManage', resourceName: 'node' },
+                      {
+                        rid: region.selection.value + '',
+                        clusterId: x.metadata.name
+                      }
+                    );
+                  }}
+                >
+                  有节点正在升级中
+                </Button>
+              </>
+            )}
             {x.status.phase !== 'Running' && <Icon className="tea-ml-1n" type="loading" />}
             {x.status.phase !== 'Running' && x.status.phase !== 'Terminating' && (
               <Button

--- a/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
@@ -18,6 +18,8 @@ export function ClusterUpdate({ route, actions }: RootProps) {
     autoMode: true
   };
 
+  const [showMaxPodUnready, setShowMaxPodUnready] = useState(true);
+
   const { clusterId, clusterVersion } = route.queries;
   const [_, clusterVersionSecondPart] = clusterVersion.split('.');
 
@@ -109,20 +111,22 @@ export function ClusterUpdate({ route, actions }: RootProps) {
           label="自动升级Worker"
           extra="注意：启用自定升级Worker，在升级完Master后，将自动升级集群下所有Worker节点。"
         >
-          <Checkbox>启用自动升级</Checkbox>
+          <Checkbox onChange={e => setShowMaxPodUnready(e.target.checked)}>启用自动升级</Checkbox>
         </Form.Item>
 
-        <Form.Item
-          label="最大不可用Pod占比"
-          extra="注意如果节点过少，而设置比例过低，没有足够多的节点承载pod的迁移会导致升级卡死。如果业务对pod可用比例较高，请考虑选择升级前不驱逐节点。"
-        >
-          <Space>
-            <Form.Item name={['maxUnready']} noStyle rules={[{ type: 'number', required: true, min: 0, max: 100 }]}>
-              <InputNumber style={ItemStyle()} min={0} max={100} />
-            </Form.Item>
-            %
-          </Space>
-        </Form.Item>
+        {showMaxPodUnready && (
+          <Form.Item
+            label="最大不可用Pod占比"
+            extra="注意如果节点过少，而设置比例过低，没有足够多的节点承载pod的迁移会导致升级卡死。如果业务对pod可用比例较高，请考虑选择升级前不驱逐节点。"
+          >
+            <Space>
+              <Form.Item name={['maxUnready']} noStyle rules={[{ type: 'number', required: true, min: 0, max: 100 }]}>
+                <InputNumber style={ItemStyle()} min={0} max={100} />
+              </Form.Item>
+              %
+            </Space>
+          </Form.Item>
+        )}
       </Form>
     </AntdLayout>
   );

--- a/web/console/src/modules/cluster/components/clusterManage/WorkerUpdate.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/WorkerUpdate.tsx
@@ -109,7 +109,7 @@ export function WorkerUpdate({ route }: RootProps) {
           </Checkbox>
         </Form.Item>
 
-        <Form.Item label="最大不可用Pod占比" extra="升级过程中不可以Pod数超过该占比将暂停升级">
+        <Form.Item label="最大不可用Pod占比" extra="升级过程中不可用Pod数超过该占比将暂停升级">
           <Space>
             <InputNumber
               style={ItemStyle()}

--- a/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodActionPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodActionPanel.tsx
@@ -182,10 +182,9 @@ export class ResourcePodActionPanel extends React.Component<RootProps, ResourceP
     // tagSearch的过滤选项
     const attributes = [
       {
-        type: 'single',
+        type: 'input',
         key: 'podName',
-        name: t('Pod名称'),
-        values: podNameValues
+        name: t('Pod名称')
       },
       {
         type: 'single',

--- a/web/console/src/webApi/cluster.ts
+++ b/web/console/src/webApi/cluster.ts
@@ -139,7 +139,7 @@ export const updateCluster = ({
           mode: autoMode ? 'Auto' : 'Manual',
           strategy: {
             drainNodeBeforeUpgrade,
-            maxUnready: maxUnready + '%'
+            maxUnready: autoMode ? maxUnready + '%' : undefined
           }
         }
       }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug

**What this PR does / why we need it**:
1. pod query can input any pod name;
2.master upgrade page ,when use manual mode ,hide max pod unready item;
3. when has worker upgrading, cluster list show loading icon  and look workers link

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

