### PR TITLE
fix(platform): upgrade gpu-manager version to fix one node with multi gpu cause gpu-manager crash

### DIFF
--- a/pkg/platform/provider/baremetal/images/images.go
+++ b/pkg/platform/provider/baremetal/images/images.go
@@ -58,7 +58,7 @@ var components = Components{
 	NvidiaDevicePlugin: containerregistry.Image{Name: "nvidia-device-plugin", Tag: "1.0.0-beta4"},
 	Keepalived:         containerregistry.Image{Name: "keepalived", Tag: "2.0.16-r0"},
 
-	GPUManager:        containerregistry.Image{Name: "gpu-manager", Tag: "v1.0.4"},
+	GPUManager:        containerregistry.Image{Name: "gpu-manager", Tag: "v1.0.6"},
 	Busybox:           containerregistry.Image{Name: "busybox", Tag: "1.31.0"},
 	GPUQuotaAdmission: containerregistry.Image{Name: "gpu-quota-admission", Tag: "v1.0.0"},
 


### PR DESCRIPTION
fix one node with muti gpu cause gpu-manager crash
