### PR TITLE
fix(platform,monitor): fix gpu-manager metrics not scraped

### DIFF
--- a/pkg/monitor/controller/prometheus/yamls.go
+++ b/pkg/monitor/controller/prometheus/yamls.go
@@ -169,7 +169,7 @@ func scrapeConfigForPrometheus() string {
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: keep
-        regex: "tke-(.*)"
+        regex: "tke-(.*)|gpu-manager-(.*)"
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
@@ -191,7 +191,7 @@ func scrapeConfigForPrometheus() string {
         replacement: $1:$2
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-        regex: 'tke_(.*)|process_(.*)|grpc_(.*)|go_(.*)|apiserver_(.*)|etcd_(.*)'
+        regex: 'tke_(.*)|process_(.*)|grpc_(.*)|go_(.*)|apiserver_(.*)|etcd_(.*)|container_gpu_utilization|container_request_gpu_utilization|container_gpu_memory_total|container_request_gpu_memory'
         action: keep
       - source_labels: [label_tkestack_io_projectName]
         action: replace

--- a/pkg/platform/controller/addon/prometheus/yamls.go
+++ b/pkg/platform/controller/addon/prometheus/yamls.go
@@ -169,7 +169,7 @@ func scrapeConfigForPrometheus() string {
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: keep
-        regex: "tke-(.*)"
+        regex: "tke-(.*)|gpu-manager-(.*)"
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
@@ -191,7 +191,7 @@ func scrapeConfigForPrometheus() string {
         replacement: $1:$2
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-        regex: 'tke_(.*)|process_(.*)|grpc_(.*)|go_(.*)|apiserver_(.*)|etcd_(.*)'
+        regex: 'tke_(.*)|process_(.*)|grpc_(.*)|go_(.*)|apiserver_(.*)|etcd_(.*)|container_gpu_utilization|container_request_gpu_utilization|container_gpu_memory_total|container_request_gpu_memory'
         action: keep
       - source_labels: [label_tkestack_io_projectName]
         action: replace


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind bug

**What this PR does / why we need it**:
fix gpu-manager metrics not scraped
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #998

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

