### PR TITLE
 [WIP][RFC stage1] add containerd as cri runtime

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/provider.go
+++ b/pkg/platform/provider/baremetal/cluster/provider.go
@@ -84,10 +84,10 @@ func NewProvider() (*Provider, error) {
 			// install packages
 			p.EnsureNvidiaDriver,
 			p.EnsureNvidiaContainerRuntime,
-			p.EnsureDocker,
+			p.EnsureCNIPlugins,
+			p.EnsureContainerRuntime,
 			p.EnsureKubernetesImages,
 			p.EnsureKubelet,
-			p.EnsureCNIPlugins,
 			p.EnsureConntrackTools,
 			p.EnsureKubeadm,
 			p.EnsureKeepalivedInit,

--- a/pkg/platform/provider/baremetal/cluster/update.go
+++ b/pkg/platform/provider/baremetal/cluster/update.go
@@ -118,7 +118,7 @@ func (p *Provider) EnsureAPIServerCert(ctx context.Context, c *v1.Cluster) error
 		if err != nil {
 			return errors.Wrap(err, machine.IP)
 		}
-		err = kubeadm.RestartContainerByFilter(s, kubeadm.DockerFilterForControlPlane("kube-apiserver"))
+		err = kubeadm.RestartContainerByLabel(s, kubeadm.ContainerLabelOfControlPlane("kube-apiserver"))
 		if err != nil {
 			return err
 		}

--- a/pkg/platform/provider/baremetal/conf/containerd/config.toml
+++ b/pkg/platform/provider/baremetal/conf/containerd/config.toml
@@ -1,0 +1,25 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/var/run/cri-runtime.sock"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "{{.SandboxImage}}"
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      {{ if .IsGPU}}
+       default_runtime_name=nvidia
+       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+            Runtime="/usr/bin/nvidia-container-runtime"
+      {{else}}
+       default_runtime_name="runc"
+      {{end}}
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        {{range .InsecureRegistries}}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.}}".tls]
+          insecure_skip_verify=true
+        {{end}}

--- a/pkg/platform/provider/baremetal/conf/containerd/containerd.service
+++ b/pkg/platform/provider/baremetal/conf/containerd/containerd.service
@@ -1,0 +1,40 @@
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=1048576
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/platform/provider/baremetal/conf/critools/crictl.yaml
+++ b/pkg/platform/provider/baremetal/conf/critools/crictl.yaml
@@ -1,0 +1,4 @@
+runtime-endpoint: unix:///var/run/cri-runtime.sock
+image-endpoint: unix:///var/run/cri-runtime.sock
+timeout: 10
+debug: false

--- a/pkg/platform/provider/baremetal/conf/kubeadm/10-kubeadm.conf
+++ b/pkg/platform/provider/baremetal/conf/kubeadm/10-kubeadm.conf
@@ -2,10 +2,11 @@
 [Service]
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+Environment="KUBELET_RUNTIME_ARGS=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/cri-runtime.sock"
 # This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
 EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/sysconfig/kubelet
 ExecStart=
-ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_RUNTIME_ARGS $KUBELET_EXTRA_ARGS

--- a/pkg/platform/provider/baremetal/machine/create.go
+++ b/pkg/platform/provider/baremetal/machine/create.go
@@ -33,7 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	platformv1 "tkestack.io/tke/api/platform/v1"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/constants"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/images"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/addons/cniplugins"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/containerd"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/critools"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/docker"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/gpu"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/kubeadm"
@@ -309,6 +312,50 @@ func (p *Provider) EnsureNvidiaContainerRuntime(ctx context.Context, machine *pl
 	}
 
 	return gpu.InstallNvidiaContainerRuntime(machineSSH, &gpu.NvidiaContainerRuntimeOption{})
+}
+
+func (p *Provider) EnsureContainerRuntime(ctx context.Context, machine *platformv1.Machine, cluster *typesv1.Cluster) error {
+	return p.EnsureContainerd(ctx, machine, cluster)
+}
+
+func (p *Provider) EnsureContainerd(ctx context.Context, machine *platformv1.Machine, cluster *typesv1.Cluster) error {
+	machineSSH, err := machine.Spec.SSH()
+	if err != nil {
+		return err
+	}
+
+	insecureRegistries := []string{p.config.Registry.Domain}
+	if p.config.Registry.NeedSetHosts() && machine.Spec.TenantID != "" {
+		insecureRegistries = append(insecureRegistries, machine.Spec.TenantID+"."+p.config.Registry.Domain)
+	}
+
+	option := &containerd.Option{
+		InsecureRegistries: insecureRegistries,
+		IsGPU:              gpu.IsEnable(machine.Spec.Labels),
+		SandboxImage:       images.Get().Pause.FullName(),
+	}
+	err = containerd.Install(machineSSH, option)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) EnsureCriTools(ctx context.Context, machine *platformv1.Machine, cluster *typesv1.Cluster) error {
+	option := &critools.Option{}
+
+	machineSSH, err := machine.Spec.SSH()
+	if err != nil {
+		return err
+	}
+
+	err = critools.Install(machineSSH, option)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *Provider) EnsureDocker(ctx context.Context, machine *platformv1.Machine, cluster *typesv1.Cluster) error {

--- a/pkg/platform/provider/baremetal/machine/kubeadm.go
+++ b/pkg/platform/provider/baremetal/machine/kubeadm.go
@@ -25,7 +25,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilsnet "k8s.io/utils/net"
 	kubeadmv1beta2 "tkestack.io/tke/pkg/platform/provider/baremetal/apis/kubeadm/v1beta2"
-	"tkestack.io/tke/pkg/platform/provider/baremetal/images"
 	v1 "tkestack.io/tke/pkg/platform/types/v1"
 	"tkestack.io/tke/pkg/util/apiclient"
 )
@@ -69,9 +68,8 @@ func (p *Provider) getKubeadmJoinConfig(c *v1.Cluster, machineIP string) *kubead
 }
 
 func (p *Provider) getKubeletExtraArgs(c *v1.Cluster) map[string]string {
-	args := map[string]string{
-		"pod-infra-container-image": images.Get().Pause.FullName(),
-	}
+	args := map[string]string{}
+	// for cri runtimes, no need to set pod-infra-container-image
 
 	utilruntime.Must(mergo.Merge(&args, c.Spec.KubeletExtraArgs))
 	utilruntime.Must(mergo.Merge(&args, p.config.Kubelet.ExtraArgs))

--- a/pkg/platform/provider/baremetal/machine/provider.go
+++ b/pkg/platform/provider/baremetal/machine/provider.go
@@ -73,7 +73,7 @@ func NewProvider() (*Provider, error) {
 
 			p.EnsureNvidiaDriver,
 			p.EnsureNvidiaContainerRuntime,
-			p.EnsureDocker,
+			p.EnsureContainerRuntime,
 			p.EnsureKubelet,
 			p.EnsureCNIPlugins,
 			p.EnsureConntrackTools,

--- a/pkg/platform/provider/baremetal/phases/containerd/containerd.go
+++ b/pkg/platform/provider/baremetal/phases/containerd/containerd.go
@@ -1,0 +1,83 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package containerd
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+
+	"tkestack.io/tke/pkg/util/template"
+
+	"github.com/pkg/errors"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/constants"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/res"
+	"tkestack.io/tke/pkg/util/ssh"
+	"tkestack.io/tke/pkg/util/supervisor"
+)
+
+type Option struct {
+	InsecureRegistries []string
+	IsGPU              bool
+	Root               string
+	SandboxImage       string
+}
+
+const (
+	containerdConfigFile = "/etc/containerd/config.toml"
+)
+
+func Install(s ssh.Interface, option *Option) error {
+	dstFile, err := res.Containerd.CopyToNodeWithDefault(s)
+	if err != nil {
+		return err
+	}
+
+	cmd := "tar xvaf %s -C %s --strip-components=1"
+	_, stderr, exit, err := s.Execf(cmd, dstFile, constants.DstBinDir)
+	if err != nil {
+		return fmt.Errorf("exec %q failed:exit %d:stderr %s:error %s", cmd, exit, stderr, err)
+	}
+
+	data, err := template.ParseFile(path.Join(constants.ConfDir, "containerd/config.toml"), option)
+	if err != nil {
+		return err
+	}
+	err = s.WriteFile(bytes.NewReader(data), containerdConfigFile)
+	if err != nil {
+		return errors.Wrapf(err, "write %s error", containerdConfigFile)
+	}
+
+	data, err = template.ParseFile(path.Join(constants.ConfDir, "containerd/containerd.service"), option)
+	if err != nil {
+		return err
+	}
+	ss := &supervisor.SystemdSupervisor{Name: "containerd", SSH: s}
+	err = ss.Deploy(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	err = ss.Start()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/platform/provider/baremetal/phases/critools/critools.go
+++ b/pkg/platform/provider/baremetal/phases/critools/critools.go
@@ -1,0 +1,66 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package critools
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+
+	"tkestack.io/tke/pkg/util/template"
+
+	"github.com/pkg/errors"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/constants"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/res"
+	"tkestack.io/tke/pkg/util/ssh"
+)
+
+type Option struct {
+	RuntimeEndPoint string
+	ImageEndpoint   string
+	TimeOut         string
+}
+
+const (
+	containerdConfigFile = "/etc/crictl.yaml"
+)
+
+func Install(s ssh.Interface, option *Option) error {
+	dstFile, err := res.CriTools.CopyToNodeWithDefault(s)
+	if err != nil {
+		return err
+	}
+
+	cmd := "tar xvaf %s -C %s --strip-components=1"
+	_, stderr, exit, err := s.Execf(cmd, dstFile, constants.DstBinDir)
+	if err != nil {
+		return fmt.Errorf("exec %q failed:exit %d:stderr %s:error %s", cmd, exit, stderr, err)
+	}
+
+	data, err := template.ParseFile(path.Join(constants.ConfDir, "cri-tools/crictl.yaml"), option)
+	if err != nil {
+		return err
+	}
+	err = s.WriteFile(bytes.NewReader(data), containerdConfigFile)
+	if err != nil {
+		return errors.Wrapf(err, "write %s error", containerdConfigFile)
+	}
+
+	return nil
+}

--- a/pkg/platform/provider/baremetal/phases/image/image.go
+++ b/pkg/platform/provider/baremetal/phases/image/image.go
@@ -20,7 +20,6 @@ package image
 
 import (
 	"fmt"
-	"strings"
 
 	"tkestack.io/tke/pkg/platform/provider/baremetal/images"
 	"tkestack.io/tke/pkg/util/ssh"
@@ -38,20 +37,11 @@ func PullKubernetesImages(s ssh.Interface, option *Option) error {
 	}
 
 	for _, image := range images {
-		cmd := fmt.Sprintf("docker pull %s", image)
+		cmd := fmt.Sprintf("crictl pull %s", image)
 		_, err := s.CombinedOutput(cmd)
 		if err != nil {
-			if strings.Contains(err.Error(), "502 Bad Gateway") {
-				cmd = " docker info | grep Proxy"
-				output, _ := s.CombinedOutput(cmd)
-				return fmt.Errorf(`pull image fail: %s. maybe set no_proxy for registry(%s,*.%s) in docker dameon.
-					docker info:%s. see: https://docs.docker.com/config/daemon/systemd/#httphttps-proxy`,
-					err, option.RegistryDomain, option.RegistryDomain, output)
-			}
-
 			return err
 		}
 	}
-
 	return nil
 }

--- a/pkg/platform/provider/baremetal/res/res.go
+++ b/pkg/platform/provider/baremetal/res/res.go
@@ -35,6 +35,17 @@ var (
 		Name:     "docker",
 		Versions: spec.DockerVersions,
 	}
+
+	Containerd = Package{
+		Name:     "containerd",
+		Versions: spec.ContainerdVersions,
+	}
+
+	CriTools = Package{
+		Name:     "cri-tools",
+		Versions: spec.CriToolsVersions,
+	}
+
 	CNIPlugins = Package{
 		Name:     "cni-plugins",
 		Versions: spec.CNIPluginsVersions,

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -41,6 +41,8 @@ var (
 	}).([]string)
 
 	DockerVersions                 = []string{"19.03.14"}
+	ContainerdVersions             = []string{"1.4.3"}
+	CriToolsVersions               = []string{"1.19.0"}
 	CNIPluginsVersions             = []string{"v0.8.6"}
 	ConntrackToolsVersions         = []string{"1.4.4"}
 	NvidiaDriverVersions           = []string{"440.31"}

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -20,8 +20,8 @@ rm -rf /etc/kubernetes
 
 systemctl stop kubelet 2>/dev/null
 
-docker rm -f $(docker ps -aq) 2>/dev/null
-systemctl stop docker 2>/dev/null
+crictl rm -f $(docker ps -aq) 2>/dev/null
+systemctl stop containerd 2>/dev/null
 
 ip link del cni0 2>/etc/null
 
@@ -30,7 +30,7 @@ for port in 80 2379 6443 8086 {10249..10259} ; do
 done
 
 rm -rfv /etc/kubernetes
-rm -rfv /etc/docker
+rm -rfv /etc/containerd
 rm -fv /root/.kube/config
 rm -rfv /var/lib/kubelet
 rm -rfv /var/lib/cni
@@ -38,4 +38,4 @@ rm -rfv /etc/cni
 rm -rfv /var/lib/etcd
 rm -rfv /var/lib/postgresql /etc/core/token /var/lib/redis /storage /chart_storage
 
-systemctl start docker 2>/dev/null
+systemctl start containerd 2>/dev/null


### PR DESCRIPTION
Signed-off-by: Liu Hua <weldonliu@tencent.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature

> /kind flake

**What this PR does / why we need it**:
refer to #1036 #991 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

