### PR TITLE
fix(application): same release name app can in different cluster

### DIFF
--- a/pkg/application/registry/application/strategy.go
+++ b/pkg/application/registry/application/strategy.go
@@ -44,12 +44,12 @@ type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 
-	applicationClient *applicationinternalclient.ApplicationClient
+	applicationClient applicationinternalclient.ApplicationInterface
 }
 
 // NewStrategy creates a strategy that is the default logic that applies when
 // creating and updating application objects.
-func NewStrategy(applicationClient *applicationinternalclient.ApplicationClient) *Strategy {
+func NewStrategy(applicationClient applicationinternalclient.ApplicationInterface) *Strategy {
 	return &Strategy{application.Scheme, namesutil.Generator, applicationClient}
 }
 

--- a/pkg/application/registry/application/validation.go
+++ b/pkg/application/registry/application/validation.go
@@ -35,7 +35,7 @@ import (
 var ValidateApplicationName = apimachineryvalidation.NameIsDNSLabel
 
 // ValidateApplication tests if required fields in the message are set.
-func ValidateApplication(ctx context.Context, app *application.App, applicationClient *applicationinternalclient.ApplicationClient) field.ErrorList {
+func ValidateApplication(ctx context.Context, app *application.App, applicationClient applicationinternalclient.ApplicationInterface) field.ErrorList {
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&app.ObjectMeta, true, ValidateApplicationName, field.NewPath("metadata"))
 
 	fldMetadataPath := field.NewPath("metadata")
@@ -68,7 +68,7 @@ func ValidateApplication(ctx context.Context, app *application.App, applicationC
 	}
 
 	applicationList, err := applicationClient.Apps(app.ObjectMeta.Namespace).List(ctx, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("spec.tenantID=%s,spec.name=%s", app.Spec.TenantID, app.Spec.Name),
+		FieldSelector: fmt.Sprintf("spec.tenantID=%s,spec.name=%s,spec.targetCluster=%s", app.Spec.TenantID, app.Spec.Name, app.Spec.TargetCluster),
 	})
 	if err != nil {
 		allErrs = append(allErrs, field.InternalError(fldSpecPath.Child("name"), err))

--- a/pkg/application/registry/application/validation_test.go
+++ b/pkg/application/registry/application/validation_test.go
@@ -1,0 +1,194 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package application
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"tkestack.io/tke/api/application"
+	"tkestack.io/tke/api/client/clientset/internalversion/fake"
+	applicationinternalclient "tkestack.io/tke/api/client/clientset/internalversion/typed/application/internalversion"
+)
+
+func TestValidateApplication_Normal(t *testing.T) {
+	cluster1 := "cls-test1"
+	clientset := fake.NewSimpleClientset()
+
+	type args struct {
+		ctx               context.Context
+		app               *application.App
+		applicationClient applicationinternalclient.ApplicationInterface
+	}
+	tests := []struct {
+		name string
+		args args
+		want field.ErrorList
+	}{
+		{
+			name: "normal app",
+			args: args{
+				ctx: context.TODO(),
+				app: &application.App{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "App",
+						APIVersion: "application.tkestack.io/v1",
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "app3",
+						Namespace: "default",
+					},
+					Spec: application.AppSpec{
+						Type:          "HelmV3",
+						TenantID:      "10001",
+						Name:          "p2p",
+						TargetCluster: cluster1,
+						Chart: application.Chart{
+							TenantID:       "10001",
+							ChartGroupName: "local",
+							ChartName:      "p2p",
+							ChartVersion:   "1.0.0",
+							RepoURL:        "http://chartmuseum:8080",
+							ImportedRepo:   true,
+						},
+						Values: application.AppValues{
+							RawValuesType: "yaml",
+							RawValues:     "",
+							Values:        []string{},
+						},
+						DryRun: false,
+					},
+				},
+				applicationClient: clientset.Application(),
+			},
+			want: field.ErrorList{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateApplication(tt.args.ctx, tt.args.app, tt.args.applicationClient); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateApplication() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateApplication_DuplicateAppInOneCluster(t *testing.T) {
+	cluster1 := "cls-test1"
+	// see https://github.com/kubernetes/code-generator/blob/release-1.18/cmd/client-gen/generators/fake/generator_fake_for_type.go
+	// k8s code generator, not support field selector.
+	app := &application.App{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "App",
+			APIVersion: "application.tkestack.io/v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "app",
+			Namespace: "default",
+		},
+		Spec: application.AppSpec{
+			Type:          "HelmV3",
+			TenantID:      "10001",
+			Name:          "p2p",
+			TargetCluster: cluster1,
+			Chart: application.Chart{
+				TenantID:       "10001",
+				ChartGroupName: "local",
+				ChartName:      "p2p",
+				ChartVersion:   "1.0.0",
+				RepoURL:        "http://chartmuseum:8080",
+				ImportedRepo:   true,
+			},
+			Values: application.AppValues{
+				RawValuesType: "yaml",
+				RawValues:     "",
+				Values:        []string{},
+			},
+			DryRun: false,
+		},
+	}
+	clientset := fake.NewSimpleClientset(app)
+
+	type args struct {
+		ctx               context.Context
+		app               *application.App
+		applicationClient applicationinternalclient.ApplicationInterface
+	}
+	tests := []struct {
+		name string
+		args args
+		want field.ErrorList
+	}{
+		{
+			name: "normal app",
+			args: args{
+				ctx: context.TODO(),
+				app: &application.App{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "App",
+						APIVersion: "application.tkestack.io/v1",
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "app2",
+						Namespace: "default",
+					},
+					Spec: application.AppSpec{
+						Type:          "HelmV3",
+						TenantID:      "10001",
+						Name:          "p2p",
+						TargetCluster: cluster1,
+						Chart: application.Chart{
+							TenantID:       "10001",
+							ChartGroupName: "local",
+							ChartName:      "p2p",
+							ChartVersion:   "1.0.0",
+							RepoURL:        "http://chartmuseum:8080",
+							ImportedRepo:   true,
+						},
+						Values: application.AppValues{
+							RawValuesType: "yaml",
+							RawValues:     "",
+							Values:        []string{},
+						},
+						DryRun: false,
+					},
+				},
+				applicationClient: clientset.Application(),
+			},
+			want: field.ErrorList{
+				&field.Error{
+					Type:     "FieldValueDuplicate",
+					Field:    "spec.name",
+					BadValue: "p2p",
+					Detail:   "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateApplication(tt.args.ctx, tt.args.app, tt.args.applicationClient); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateApplication() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:
same spec.name(helm chart release name) app can not in different cluster.

**Which issue(s) this PR fixes**:
Fixes #1041

**Special notes for your reviewer**:
@jianzzz I didn't modify the tenantID as we discussed yesterday because I learned that the cluster belongs to a tenantID, so the tenantID is irrelevant. Before I thought the cluster can correspond to multiple tenantIDs. 
The search scene is compatible with my modified conditions and more flexible. 👍

**Does this PR introduce a user-facing change?**:
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

