### PR TITLE
fix(platform): fix controller panic when GC deleted cluster

### DIFF
--- a/pkg/platform/controller/cluster/deletion/cluster_deleter.go
+++ b/pkg/platform/controller/cluster/deletion/cluster_deleter.go
@@ -394,6 +394,10 @@ func deleteClusterProvider(ctx context.Context, deleter *clusterDeleter, cluster
 	if err != nil {
 		return err
 	}
+	// cluster credential is nil, do nothing.
+	if clusterWrapper.ClusterCredential == nil {
+		return nil
+	}
 
 	err = provider.OnDelete(ctx, clusterWrapper)
 	if err != nil {

--- a/pkg/platform/types/v1/types.go
+++ b/pkg/platform/types/v1/types.go
@@ -139,6 +139,10 @@ func (c *Cluster) RESTConfig(config *rest.Config) (*rest.Config, error) {
 		return nil, err
 	}
 
+	if c.ClusterCredential == nil {
+		return nil, fmt.Errorf("cluster credential is nil, get restconfig failed")
+	}
+
 	if c.ClusterCredential.CACert != nil {
 		config.TLSClientConfig.CAData = c.ClusterCredential.CACert
 	} else {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**: 
controller use cluster credential to get kubernetes client, so platform controller will panic if deleted cluster credential is nil.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # [1091](https://github.com/tkestack/tke/issues/1091)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
