### PR TITLE
fix(console): open cluster monitor get error

### DIFF
--- a/web/console/src/modules/cluster/components/clusterManage/ClusterTablePanel.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/ClusterTablePanel.tsx
@@ -111,22 +111,25 @@ export class ClusterTablePanel extends React.Component<RootProps, State> {
         key: 'monitor',
         header: t('监控'),
         width: '7%',
-        render: x => (
-          <div>
-            <p className="text-overflow m-width">
-              <i
-                className="dosage-icon"
-                style={{ cursor: 'pointer' }}
-                data-monitor
-                data-title={t('查看监控')}
-                onClick={() => {
-                  this._handleMonitor(x);
-                }}
-              />
-              {/* {!x.clusterBMonitor && <span className="alarm-label-tips">{t('未配告警')}</span>} */}
-            </p>
-          </div>
-        )
+        render: x => {
+          const { promethus } = x.spec;
+          return (
+            <div>
+              <p className="text-overflow m-width">
+                <i
+                  className="dosage-icon"
+                  style={{ cursor: promethus ? 'pointer' : 'not-allowed' }}
+                  data-monitor
+                  data-title={promethus ? t('查看监控') : '监控告警组件未开启'}
+                  onClick={() => {
+                    promethus && this._handleMonitor(x);
+                  }}
+                />
+                {/* {!x.clusterBMonitor && <span className="alarm-label-tips">{t('未配告警')}</span>} */}
+              </p>
+            </div>
+          );
+        }
       },
       {
         key: 'status',


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug
![image](https://user-images.githubusercontent.com/15609400/108684550-018e9900-752e-11eb-80b3-cda2363ae907.png)


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

