### PR TITLE
fix(platform,monitor): set replica of alertmanager to 1

### DIFF
--- a/pkg/monitor/controller/prometheus/controller.go
+++ b/pkg/monitor/controller/prometheus/controller.go
@@ -1550,7 +1550,7 @@ func createAlertManagerCRD(components images.Components, prometheus *v1.Promethe
 				},
 			},
 			BaseImage: containerregistryutil.GetImagePrefix(alertManagerImagePath),
-			Replicas:  controllerutil.Int32Ptr(3),
+			Replicas:  controllerutil.Int32Ptr(1),
 			SecurityContext: &corev1.PodSecurityContext{
 				FSGroup:      controllerutil.Int64Ptr(2000),
 				RunAsNonRoot: controllerutil.BoolPtr(true),

--- a/pkg/platform/controller/addon/prometheus/controller.go
+++ b/pkg/platform/controller/addon/prometheus/controller.go
@@ -1520,7 +1520,7 @@ func createAlertManagerCRD(components images.Components, prometheus *v1.Promethe
 				},
 			},
 			BaseImage: containerregistryutil.GetImagePrefix(alertManagerImagePath),
-			Replicas:  controllerutil.Int32Ptr(3),
+			Replicas:  controllerutil.Int32Ptr(1),
 			SecurityContext: &corev1.PodSecurityContext{
 				FSGroup:      controllerutil.Int64Ptr(2000),
 				RunAsNonRoot: controllerutil.BoolPtr(true),


### PR DESCRIPTION
Signed-off-by: Feng Kun <fengkun32@gmail.com>

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
set replica of alertmanager to 1 to avoid cluster split

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

