### PR TITLE
Revert "fix(console): remove "context" from  kubeconfig name"

### DIFF
--- a/web/console/helpers/downloadCrt.ts
+++ b/web/console/helpers/downloadCrt.ts
@@ -81,7 +81,7 @@ contexts:
 - context:
     cluster: ${clusterId}
     user: ${clusterId}-admin
-  name: ${clusterId}-default
+  name: ${clusterId}-context-default
 current-context: ${clusterId}-context-default
 kind: Config
 preferences: {}


### PR DESCRIPTION
Reverts tkestack/tke#1085