### PR TITLE
feat(platform): declare default table convertor

### DIFF
--- a/pkg/application/registry/application/storage/storage.go
+++ b/pkg/application/registry/application/storage/storage.go
@@ -66,6 +66,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter,
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    applicationtrategy.GetAttrs,

--- a/pkg/application/registry/configmap/storage/storage.go
+++ b/pkg/application/registry/configmap/storage/storage.go
@@ -50,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/auth/registry/apikey/storage/storage.go
+++ b/pkg/auth/registry/apikey/storage/storage.go
@@ -63,6 +63,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		PredicateFunc: apikey.MatchAPIKey,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    apikey.GetAttrs,

--- a/pkg/auth/registry/apisigningkey/storage/storage.go
+++ b/pkg/auth/registry/apisigningkey/storage/storage.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"tkestack.io/tke/api/auth"
 	"tkestack.io/tke/pkg/auth/registry/apisigningkey"
 	"tkestack.io/tke/pkg/util/log"
@@ -44,6 +45,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) *Storage {
 		UpdateStrategy: strategy,
 		DeleteStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 
 	if err := store.CompleteWithOptions(options); err != nil {

--- a/pkg/auth/registry/category/storage/storage.go
+++ b/pkg/auth/registry/category/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -49,6 +50,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 		UpdateStrategy: strategy,
 		DeleteStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    category.GetAttrs,

--- a/pkg/auth/registry/configmap/storage/storage.go
+++ b/pkg/auth/registry/configmap/storage/storage.go
@@ -50,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/auth/registry/custompolicybinding/storage/storage.go
+++ b/pkg/auth/registry/custompolicybinding/storage/storage.go
@@ -67,6 +67,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		ShouldDeleteDuringUpdate: custompolicybinding.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    custompolicybinding.GetAttrs,

--- a/pkg/auth/registry/identityprovider/storage/storage.go
+++ b/pkg/auth/registry/identityprovider/storage/storage.go
@@ -58,6 +58,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		PredicateFunc: identityprovider.MatchAPIKey,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    identityprovider.GetAttrs,

--- a/pkg/auth/registry/localgroup/storage/storage.go
+++ b/pkg/auth/registry/localgroup/storage/storage.go
@@ -77,6 +77,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		ShouldDeleteDuringUpdate: localgroup.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    localgroup.GetAttrs,

--- a/pkg/auth/registry/localidentity/storage/storage.go
+++ b/pkg/auth/registry/localidentity/storage/storage.go
@@ -75,6 +75,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 		PredicateFunc:            localidentity.MatchLocalIdentity,
 		ShouldDeleteDuringUpdate: localidentity.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    localidentity.GetAttrs,

--- a/pkg/auth/registry/policy/storage/storage.go
+++ b/pkg/auth/registry/policy/storage/storage.go
@@ -81,6 +81,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		ShouldDeleteDuringUpdate: policy.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    policy.GetAttrs,

--- a/pkg/auth/registry/projectpolicybinding/storage/storage.go
+++ b/pkg/auth/registry/projectpolicybinding/storage/storage.go
@@ -70,6 +70,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		ShouldDeleteDuringUpdate: projectpolicybinding.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    projectpolicybinding.GetAttrs,

--- a/pkg/auth/registry/role/storage/storage.go
+++ b/pkg/auth/registry/role/storage/storage.go
@@ -79,6 +79,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, authClient authinternalcli
 
 		ShouldDeleteDuringUpdate: role.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    role.GetAttrs,

--- a/pkg/auth/registry/rule/storage/storage.go
+++ b/pkg/auth/registry/rule/storage/storage.go
@@ -51,6 +51,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) *Storage {
 		CreateStrategy: strategy,
 		DeleteStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    rule.GetAttrs,

--- a/pkg/business/registry/chartgroup/storage/storage.go
+++ b/pkg/business/registry/chartgroup/storage/storage.go
@@ -64,6 +64,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, businessClient *bu
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    chartgroup.GetAttrs,

--- a/pkg/business/registry/configmap/storage/storage.go
+++ b/pkg/business/registry/configmap/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -49,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/business/registry/emigration/storage/storage.go
+++ b/pkg/business/registry/emigration/storage/storage.go
@@ -61,6 +61,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, businessClient *bu
 
 		ShouldDeleteDuringUpdate: registry.ShouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    emigration.GetAttrs,

--- a/pkg/business/registry/imagenamespace/storage/storage.go
+++ b/pkg/business/registry/imagenamespace/storage/storage.go
@@ -66,6 +66,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, businessClient *bu
 
 		ShouldDeleteDuringUpdate: shouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    imagenamespace.GetAttrs,

--- a/pkg/business/registry/namespace/storage/storage.go
+++ b/pkg/business/registry/namespace/storage/storage.go
@@ -80,6 +80,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, businessClient *bu
 
 		ShouldDeleteDuringUpdate: shouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    namespace.GetAttrs,

--- a/pkg/business/registry/platform/storage/storage.go
+++ b/pkg/business/registry/platform/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, businessClient *bu
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    platformstrategy.GetAttrs,

--- a/pkg/business/registry/project/storage/storage.go
+++ b/pkg/business/registry/project/storage/storage.go
@@ -74,6 +74,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter,
 
 		ShouldDeleteDuringUpdate: shouldDeleteDuringUpdate,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 
 	if err := store.CompleteWithOptions(&genericregistry.StoreOptions{
 		RESTOptions: optsGetter,

--- a/pkg/logagent/registry/configmap/storage/storage.go
+++ b/pkg/logagent/registry/configmap/storage/storage.go
@@ -50,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/logagent/registry/logagent/storage/storage.go
+++ b/pkg/logagent/registry/logagent/storage/storage.go
@@ -62,7 +62,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    registrylogagent.GetAttrs,

--- a/pkg/mesh/registry/configmap/storage/storage.go
+++ b/pkg/mesh/registry/configmap/storage/storage.go
@@ -51,7 +51,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/mesh/registry/meshmanager/storage/storage.go
+++ b/pkg/mesh/registry/meshmanager/storage/storage.go
@@ -57,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    meshmanagerstrategy.GetAttrs,

--- a/pkg/monitor/registry/configmap/storage/storage.go
+++ b/pkg/monitor/registry/configmap/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -49,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/monitor/registry/prometheus/storage/storage.go
+++ b/pkg/monitor/registry/prometheus/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    prometheus.GetAttrs,

--- a/pkg/notify/registry/channel/storage/storage.go
+++ b/pkg/notify/registry/channel/storage/storage.go
@@ -21,6 +21,7 @@ package storage
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,6 +62,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    channelstrategy.GetAttrs,

--- a/pkg/notify/registry/configmap/storage/storage.go
+++ b/pkg/notify/registry/configmap/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -49,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/notify/registry/message/storage/storage.go
+++ b/pkg/notify/registry/message/storage/storage.go
@@ -20,6 +20,8 @@ package storage
 
 import (
 	"context"
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +29,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"time"
 	"tkestack.io/tke/api/notify"
 	"tkestack.io/tke/pkg/apiserver/authentication"
 	apiserverutil "tkestack.io/tke/pkg/apiserver/util"
@@ -60,6 +61,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    messagestrategy.GetAttrs,

--- a/pkg/notify/registry/messagerequest/storage/storage.go
+++ b/pkg/notify/registry/messagerequest/storage/storage.go
@@ -20,6 +20,8 @@ package storage
 
 import (
 	"context"
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +29,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"time"
 	notifyinternalclient "tkestack.io/tke/api/client/clientset/internalversion/typed/notify/internalversion"
 	"tkestack.io/tke/api/notify"
 	"tkestack.io/tke/pkg/apiserver/authentication"
@@ -61,6 +62,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, notifyClient *noti
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    messagerequeststrategy.GetAttrs,

--- a/pkg/notify/registry/receiver/storage/storage.go
+++ b/pkg/notify/registry/receiver/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    receiverstrategy.GetAttrs,

--- a/pkg/notify/registry/receivergroup/storage/storage.go
+++ b/pkg/notify/registry/receivergroup/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, notifyClient *noti
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    receivergroupstrategy.GetAttrs,

--- a/pkg/notify/registry/template/storage/storage.go
+++ b/pkg/notify/registry/template/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, notifyClient *noti
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    templatestrategy.GetAttrs,

--- a/pkg/platform/registry/cluster/storage/storage.go
+++ b/pkg/platform/registry/cluster/storage/storage.go
@@ -83,6 +83,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, platformClient pla
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(AddHandlers)},
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    clusterstrategy.GetAttrs,

--- a/pkg/platform/registry/clustercredential/storage/storage.go
+++ b/pkg/platform/registry/clustercredential/storage/storage.go
@@ -57,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, platformClient pla
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    clustercredential.GetAttrs,

--- a/pkg/platform/registry/configmap/storage/storage.go
+++ b/pkg/platform/registry/configmap/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -49,6 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/platform/registry/cronhpa/storage/storage.go
+++ b/pkg/platform/registry/cronhpa/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    cronhpa.GetAttrs,

--- a/pkg/platform/registry/csioperator/storage/storage.go
+++ b/pkg/platform/registry/csioperator/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"tkestack.io/tke/pkg/apiserver/authentication"
 
@@ -57,6 +58,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    csioperator.GetAttrs,

--- a/pkg/platform/registry/helm/storage/storage.go
+++ b/pkg/platform/registry/helm/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, platformClient pla
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    helm.GetAttrs,

--- a/pkg/platform/registry/ipam/storage/storage.go
+++ b/pkg/platform/registry/ipam/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    ipam.GetAttrs,

--- a/pkg/platform/registry/lbcf/storage/storage.go
+++ b/pkg/platform/registry/lbcf/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, platformClient pla
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    lbcf.GetAttrs,

--- a/pkg/platform/registry/logcollector/storage/storage.go
+++ b/pkg/platform/registry/logcollector/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"tkestack.io/tke/pkg/apiserver/authentication"
 
@@ -57,6 +58,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    logcollector.GetAttrs,

--- a/pkg/platform/registry/persistentevent/storage/storage.go
+++ b/pkg/platform/registry/persistentevent/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    persistentevent.GetAttrs,

--- a/pkg/platform/registry/prometheus/storage/storage.go
+++ b/pkg/platform/registry/prometheus/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    prometheus.GetAttrs,

--- a/pkg/platform/registry/registry/storage/storage.go
+++ b/pkg/platform/registry/registry/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, privilegedUsername string)
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &generic.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    registry.GetAttrs,

--- a/pkg/platform/registry/tappcontroller/storage/storage.go
+++ b/pkg/platform/registry/tappcontroller/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    tappcontroller.GetAttrs,

--- a/pkg/platform/registry/volumedecorator/storage/storage.go
+++ b/pkg/platform/registry/volumedecorator/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"tkestack.io/tke/pkg/apiserver/authentication"
 
@@ -57,6 +58,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, privilegedUsername
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    volumedecorator.GetAttrs,

--- a/pkg/registry/registry/chart/storage/storage.go
+++ b/pkg/registry/registry/chart/storage/storage.go
@@ -71,6 +71,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter,
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    chartstrategy.GetAttrs,

--- a/pkg/registry/registry/chartgroup/storage/storage.go
+++ b/pkg/registry/registry/chartgroup/storage/storage.go
@@ -72,6 +72,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter,
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    chartgroupstrategy.GetAttrs,

--- a/pkg/registry/registry/configmap/storage/storage.go
+++ b/pkg/registry/registry/configmap/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"context"
+
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
@@ -49,7 +50,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter) *Storage {
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
-
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 	}

--- a/pkg/registry/registry/namespace/storage/storage.go
+++ b/pkg/registry/registry/namespace/storage/storage.go
@@ -61,6 +61,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, registryClient *re
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    namespacestrategy.GetAttrs,

--- a/pkg/registry/registry/repository/storage/storage.go
+++ b/pkg/registry/registry/repository/storage/storage.go
@@ -61,6 +61,7 @@ func NewStorage(optsGetter genericregistry.RESTOptionsGetter, registryClient *re
 		DeleteStrategy: strategy,
 		ExportStrategy: strategy,
 	}
+	store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
 	options := &genericregistry.StoreOptions{
 		RESTOptions: optsGetter,
 		AttrFunc:    repositorystrategy.GetAttrs,


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

related https://github.com/tkestack/tke/issues/1082.

K8s 1.19+ requires a table converter explicitly. 

If no table convertor is declared, adding a default table convertor for storage implementations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

