### PR TITLE
fix(platform): remove v in same version comparing

### DIFF
--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm.go
@@ -674,6 +674,8 @@ func AddNeedUpgradeLabel(platformClient platformv1client.PlatformV1Interface, cl
 }
 
 func sameVersion(ver1, ver2 string, ignorePatchVersion bool) (bool, error) {
+	ver1 = strings.TrimPrefix(ver1, "v")
+	ver2 = strings.TrimPrefix(ver2, "v")
 	semVer1, err := semver.NewVersion(ver1)
 	if err != nil {
 		return false, err

--- a/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm_test.go
+++ b/pkg/platform/provider/baremetal/phases/kubeadm/kubeadm_test.go
@@ -44,10 +44,29 @@ func Test_sameVersion(t *testing.T) {
 			false,
 		},
 		{
+			"same version with v",
+			args{
+				ver1: "1.20.4",
+				ver2: "v1.20.4",
+			},
+			true,
+			false,
+		},
+		{
 			"diffrent version",
 			args{
 				ver1: "1.20.4",
 				ver2: "1.20.4-tke.1",
+			},
+			false,
+			false,
+		},
+		{
+			"diffrent minor version",
+			args{
+				ver1:               "1.19.4",
+				ver2:               "1.20.4",
+				ignorePatchVersion: true,
 			},
 			false,
 			false,
@@ -61,6 +80,26 @@ func Test_sameVersion(t *testing.T) {
 			},
 			true,
 			false,
+		},
+		{
+			"same inc version with v",
+			args{
+				ver1:               "v1.20.4-tke.1",
+				ver2:               "1.20.4-tke.1",
+				ignorePatchVersion: false,
+			},
+			true,
+			false,
+		},
+		{
+			"empty",
+			args{
+				ver1:               "",
+				ver2:               "1.20.4-tke.1",
+				ignorePatchVersion: false,
+			},
+			false,
+			true,
 		},
 		// TODO: Add test cases.
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug


**What this PR does / why we need it**:

v1.20.4 should be same with 1.20.4

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

