### PR TITLE
fix(webconsole): rewritten clustercredential into abbreviated

### DIFF
--- a/web/console/src/modules/cluster/WebAPI/ClusterAPI.ts
+++ b/web/console/src/modules/cluster/WebAPI/ClusterAPI.ts
@@ -298,7 +298,7 @@ export async function createImportClsutter(resource: CreateResource[], regionId:
 
     const clustercredentialData = {
       metadata: {
-        generateName: 'clustercredential'
+        generateName: 'cc'
       },
       caCert: clusterData.status.credential.caCert,
       token: clusterData.status.credential.token ? clusterData.status.credential.token : undefined,


### PR DESCRIPTION
…istency with the backend

**What type of PR is this?**
 kind bug

**What this PR does / why we need it**:

This PR rewritten clustercredential into abbreviated form cc to keep the  cluster credential naming style  maintain consistency which baremetal cluster created and imported cluster created.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #1164`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1164

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

