### PR TITLE
fix(console): k8s version updgrade and kubeconfig wrong

### DIFF
--- a/web/console/helpers/downloadCrt.ts
+++ b/web/console/helpers/downloadCrt.ts
@@ -74,7 +74,7 @@ export function getKubectlConfig({ caCert, token, host, clusterId, clientKey, cl
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: ${caCert}
+    ${caCert ? `certificate-authority-data: ${caCert}` : `insecure-skip-tls-verify: true`}
     server: ${host}
   name: ${clusterId}
 contexts:

--- a/web/console/helpers/version.ts
+++ b/web/console/helpers/version.ts
@@ -17,7 +17,7 @@ export const compareVersion = (firstVersion: string, secondVersion: string) => {
   if (firstVersionPart2 === secondVersionPart2) return 0;
 
   // firstVersionPart2不存在
-  if (firstVersionPart1 === undefined) return -1;
+  if (firstVersionPart2 === undefined) return -1;
 
   // secondVersionPart2不存在
   if (secondVersionPart2 === undefined) return 1;

--- a/web/console/helpers/version.ts
+++ b/web/console/helpers/version.ts
@@ -1,0 +1,27 @@
+import compareVersions from 'compare-versions';
+
+export const compareVersion = (firstVersion: string, secondVersion: string) => {
+  // 判断是否包含“-”， 因为项目这边：1.20.4-tke.1 版本号是大于1.20.4的
+  const [firstVersionPart1, firstVersionPart2] = firstVersion.split('-');
+  const [secondVersionPart1, secondVersionPart2] = secondVersion.split('-');
+
+  const compareResult = compareVersions(firstVersionPart1, secondVersionPart1);
+
+  // 第一部分可以判断出大小
+  if (compareResult !== 0) return compareResult;
+
+  // 第二部分都不存在
+  if (firstVersionPart2 === undefined && secondVersionPart2 === undefined) return 0;
+
+  // 第二部分也相同
+  if (firstVersionPart2 === secondVersionPart2) return 0;
+
+  // firstVersionPart2不存在
+  if (firstVersionPart1 === undefined) return -1;
+
+  // secondVersionPart2不存在
+  if (secondVersionPart2 === undefined) return 1;
+
+  // 第二部分都存在
+  return compareVersions(firstVersion, secondVersion);
+};

--- a/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
+++ b/web/console/src/modules/cluster/components/clusterManage/ClusterUpdate.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Space, Button, Form, Select, Checkbox, InputNumber, Typography } from 'antd';
 import { AntdLayout } from '@src/modules/common/layouts';
 import { getK8sValidVersions } from '@src/webApi/cluster';
-import { compare } from 'compare-versions';
+import { compareVersion } from '@helper/version';
 import { RootProps } from '../ClusterApp';
 import { updateCluster } from '@src/webApi/cluster';
 
@@ -89,7 +89,7 @@ export function ClusterUpdate({ route, actions }: RootProps) {
         >
           <Select style={ItemStyle()}>
             {k8sValidVersions.map(v => (
-              <Select.Option key={v} disabled={compare(clusterVersion, v, '>=')} value={v}>
+              <Select.Option key={v} disabled={compareVersion(clusterVersion, v) >= 0} value={v}>
                 {v}
               </Select.Option>
             ))}

--- a/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/resourceDetail/ResourcePodPanel.tsx
@@ -229,7 +229,7 @@ export class ResourcePodPanel extends React.Component<RootProps, ResourcePodPane
         // render: x => this._getDays(x.status.startTime)
         render: x => (
           <Bubble content={`创建时间：${moment(x.metadata.creationTimestamp).format('YYYY-MM-DD HH:mm:ss')}`}>
-            <Text>{this.runningTime(x.status.startTime)}</Text>
+            <Text>{this._getDays(x.status.startTime)}</Text>
           </Bubble>
         )
       },
@@ -522,7 +522,7 @@ export class ResourcePodPanel extends React.Component<RootProps, ResourcePodPane
     return <Text>{`${first} ${second}`}</Text>;
   }
 
-  private runningTime = (startTime: string) => moment.duration(moment().diff(moment(startTime))).humanize(true);
+  private runningTime = (startTime: string) => moment.duration(moment().diff(moment(startTime))).humanize();
 
   /** 运行时间 */
   private _getDays(startTime: string) {

--- a/web/console/src/webApi/cluster.ts
+++ b/web/console/src/webApi/cluster.ts
@@ -1,5 +1,5 @@
 import Request from './request';
-import { compare } from 'compare-versions';
+import { compareVersion } from '@helper/version';
 
 function transObjToelector(obj: { [key: string]: string | number }) {
   return Object.entries(obj)
@@ -90,7 +90,7 @@ export const checkClusterIsNeedUpdate = async ({
 
   // checkversion
   const canUpdateVersions = await getK8sValidVersions();
-  if (canUpdateVersions.findIndex(v => compare(v, clusterVersion, '>')) < 0) {
+  if (canUpdateVersions.findIndex(v => compareVersion(v, clusterVersion) === 1) < 0) {
     return {
       master: {
         isNeed: false,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug


**What this PR does / why we need it**:
1、fix 1.20.4 can't upgrade to 1.20.4-tke.1
2、fix when not have cacert, display undefined in kubeconfig
3、fix pod running duration display wrong

**Which issue(s) this PR fixes**:
https://github.com/tkestack/tke/issues/1168

https://github.com/tkestack/tke/issues/1173
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

