### PR TITLE
fix(platform): networking v1beta1 do NOT support status and event

### DIFF
--- a/pkg/platform/proxy/networking/ingress/storage/event.go
+++ b/pkg/platform/proxy/networking/ingress/storage/event.go
@@ -1,0 +1,112 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package storage
+
+import (
+	"context"
+
+	"tkestack.io/tke/pkg/platform/proxy"
+	"tkestack.io/tke/pkg/util/apiclient"
+
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/kubernetes"
+	platforminternalclient "tkestack.io/tke/api/client/clientset/internalversion/typed/platform/internalversion"
+)
+
+// EventREST implements the REST endpoint for find events by a daemonset.
+type EventREST struct {
+	rest.Storage
+
+	platformClient platforminternalclient.PlatformInterface
+}
+
+var _ rest.Getter = &EventREST{}
+var _ rest.GroupVersionKindProvider = &EventREST{}
+
+// GroupVersionKind is used to specify a particular GroupVersionKind to discovery.
+func (r *EventREST) GroupVersionKind(_ schema.GroupVersion) schema.GroupVersionKind {
+	return corev1.SchemeGroupVersion.WithKind("EventList")
+}
+
+// New returns an empty object that can be used with Create and Update after
+// request data has been put into it.
+func (r *EventREST) New() runtime.Object {
+	return &corev1.EventList{}
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *EventREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	client, err := proxy.ClientSet(ctx, r.platformClient)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceName, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, errors.NewBadRequest("a namespace must be specified")
+	}
+
+	if apiclient.ClusterVersionIsBefore116(client) {
+		return listEventsByExtensions(ctx, client, namespaceName, name, options)
+	}
+	return listEventsByNetworkings(ctx, client, namespaceName, name, options)
+}
+
+func listEventsByExtensions(ctx context.Context, client *kubernetes.Clientset, namespaceName, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	ingress, err := client.ExtensionsV1beta1().Ingresses(namespaceName).Get(ctx, name, *options)
+	if err != nil {
+		return nil, errors.NewNotFound(extensionsv1beta1.Resource("ingresses/events"), name)
+	}
+
+	selector := fields.AndSelectors(
+		fields.OneTermEqualSelector("involvedObject.uid", string(ingress.UID)),
+		fields.OneTermEqualSelector("involvedObject.name", ingress.Name),
+		fields.OneTermEqualSelector("involvedObject.namespace", ingress.Namespace),
+		fields.OneTermEqualSelector("involvedObject.kind", "Ingress"))
+	listOptions := metav1.ListOptions{
+		FieldSelector: selector.String(),
+	}
+	return client.CoreV1().Events(namespaceName).List(ctx, listOptions)
+}
+
+func listEventsByNetworkings(ctx context.Context, client *kubernetes.Clientset, namespaceName, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	ingress, err := client.NetworkingV1beta1().Ingresses(namespaceName).Get(ctx, name, *options)
+	if err != nil {
+		return nil, errors.NewNotFound(networkingv1beta1.Resource("ingresses/events"), name)
+	}
+
+	selector := fields.AndSelectors(
+		fields.OneTermEqualSelector("involvedObject.uid", string(ingress.UID)),
+		fields.OneTermEqualSelector("involvedObject.name", ingress.Name),
+		fields.OneTermEqualSelector("involvedObject.namespace", ingress.Namespace),
+		fields.OneTermEqualSelector("involvedObject.kind", "Ingress"))
+	listOptions := metav1.ListOptions{
+		FieldSelector: selector.String(),
+	}
+	return client.CoreV1().Events(namespaceName).List(ctx, listOptions)
+}

--- a/pkg/platform/proxy/networking/rest/rest.go
+++ b/pkg/platform/proxy/networking/rest/rest.go
@@ -19,7 +19,7 @@
 package rest
 
 import (
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -81,7 +81,9 @@ func (s *StorageProvider) v1Beta1Storage(restOptionsGetter generic.RESTOptionsGe
 	networkPolicyStore := ingressstorage.NewStorageV1Beta1(restOptionsGetter, platformClient)
 
 	storageMap := map[string]rest.Storage{
-		"ingresses": networkPolicyStore.Ingress,
+		"ingresses":        networkPolicyStore.Ingress,
+		"ingresses/status": networkPolicyStore.Status,
+		"ingresses/events": networkPolicyStore.Events,
 	}
 
 	return storageMap


### PR DESCRIPTION
(cherry picked from commit b9070b08ee6bf80ff93939bfc53493258f41333e)

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

