### PR TITLE
fix(docs,installer): limit thanos-receive-nodeport svc port to expose

### DIFF
--- a/cmd/tke-installer/app/installer/manifests/thanos/thanos.yaml
+++ b/cmd/tke-installer/app/installer/manifests/thanos/thanos.yaml
@@ -44,19 +44,9 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: thanos-receive-nodeport
   name: thanos-receive-nodeport
-  namespace: kube-system
+  namespace: tke
 spec:
   ports:
-    - name: grpc
-      port: 10901
-      protocol: TCP
-      targetPort: 10901
-      nodePort: 31139
-    - name: http
-      port: 10902
-      protocol: TCP
-      targetPort: 10902
-      nodePort: 31140
     - name: remote-write
       port: 19291
       protocol: TCP

--- a/docs/design-proposals/installer-thanos-support.md
+++ b/docs/design-proposals/installer-thanos-support.md
@@ -30,7 +30,7 @@
   | Store    | global集群                        | 10901 : <br>10902 : <br>                              |
   | Compact  | global集群                        | 10902 : <br>                                          |
   | Rule     | global集群                        | 10901 : <br/>10902 : <br/>                            |
-  | Receiver | 业务集群，Prometheus Remote Write | 10901 : 31139<br/>10902 : 31140<br/>19291 : 31141<br> |
+  | Receiver | 业务集群，Prometheus Remote Write | 19291 : 31141<br> |
 
 - 配置tke-monitor/tke-platform-controller为thanos对应组件地址
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

