### PR TITLE
fix(monitor): convert elastic password bytes to string

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1978,14 +1978,14 @@ func (t *TKE) installTKEMonitorAPI(ctx context.Context) error {
 			options["StorageType"] = "es"
 			options["StorageAddress"] = t.Para.Config.Monitor.ESMonitor.URL
 			options["StorageUsername"] = t.Para.Config.Monitor.ESMonitor.Username
-			options["StoragePassword"] = t.Para.Config.Monitor.ESMonitor.Password
+			options["StoragePassword"] = string(t.Para.Config.Monitor.ESMonitor.Password)
 		} else if t.Para.Config.Monitor.InfluxDBMonitor != nil {
 			options["StorageType"] = "influxDB"
 
 			if t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor != nil {
 				options["StorageAddress"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.URL
 				options["StorageUsername"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username
-				options["StoragePassword"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password
+				options["StoragePassword"] = string(t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password)
 			} else if t.Para.Config.Monitor.InfluxDBMonitor.LocalInfluxDBMonitor != nil {
 				// todo
 				options["StorageAddress"] = fmt.Sprintf("http://%s:8086", t.servers[0])
@@ -2026,7 +2026,7 @@ func (t *TKE) installTKEMonitorController(ctx context.Context) error {
 			params["StorageType"] = "es"
 			params["StorageAddress"] = address
 			params["StorageUsername"] = t.Para.Config.Monitor.ESMonitor.Username
-			params["StoragePassword"] = t.Para.Config.Monitor.ESMonitor.Password
+			params["StoragePassword"] = string(t.Para.Config.Monitor.ESMonitor.Password)
 			params["MonitorStorageType"] = "elasticsearch"
 			if t.Para.Config.Monitor.ESMonitor.Username != "" {
 				address = address + "&u=" + t.Para.Config.Monitor.ESMonitor.Username
@@ -2042,7 +2042,7 @@ func (t *TKE) installTKEMonitorController(ctx context.Context) error {
 				address := t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.URL
 				params["StorageAddress"] = address
 				params["StorageUsername"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username
-				params["StoragePassword"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password
+				params["StoragePassword"] = string(t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password)
 				if t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username != "" {
 					address = address + "&u=" + t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username
 				}

--- a/cmd/tke-upgrade/app/options/options.go
+++ b/cmd/tke-upgrade/app/options/options.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+
 	platformv1 "tkestack.io/tke/api/platform/v1"
 	v1 "tkestack.io/tke/api/platform/v1"
 	"tkestack.io/tke/cmd/tke-installer/app/config"
@@ -236,14 +237,14 @@ func (t *TKE) TKEMonitorAPI() (option Options) {
 			option["StorageType"] = "es"
 			option["StorageAddress"] = t.Para.Config.Monitor.ESMonitor.URL
 			option["StorageUsername"] = t.Para.Config.Monitor.ESMonitor.Username
-			option["StoragePassword"] = t.Para.Config.Monitor.ESMonitor.Password
+			option["StoragePassword"] = string(t.Para.Config.Monitor.ESMonitor.Password)
 		} else if t.Para.Config.Monitor.InfluxDBMonitor != nil {
 			option["StorageType"] = "influxDB"
 
 			if t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor != nil {
 				option["StorageAddress"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.URL
 				option["StorageUsername"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username
-				option["StoragePassword"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password
+				option["StoragePassword"] = string(t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password)
 			} else if t.Para.Config.Monitor.InfluxDBMonitor.LocalInfluxDBMonitor != nil {
 				// todo
 				option["StorageAddress"] = fmt.Sprintf("http://%s:8086", t.Servers[0])
@@ -265,14 +266,14 @@ func (t *TKE) TKEMonitorController() (option Options) {
 			option["StorageType"] = "es"
 			option["StorageAddress"] = t.Para.Config.Monitor.ESMonitor.URL
 			option["StorageUsername"] = t.Para.Config.Monitor.ESMonitor.Username
-			option["StoragePassword"] = t.Para.Config.Monitor.ESMonitor.Password
+			option["StoragePassword"] = string(t.Para.Config.Monitor.ESMonitor.Password)
 		} else if t.Para.Config.Monitor.InfluxDBMonitor != nil {
 			option["StorageType"] = "influxDB"
 
 			if t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor != nil {
 				option["StorageAddress"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.URL
 				option["StorageUsername"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Username
-				option["StoragePassword"] = t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password
+				option["StoragePassword"] = string(t.Para.Config.Monitor.InfluxDBMonitor.ExternalInfluxDBMonitor.Password)
 			} else if t.Para.Config.Monitor.InfluxDBMonitor.LocalInfluxDBMonitor != nil {
 				option["StorageAddress"] = fmt.Sprintf("http://%s:8086", t.Servers[0])
 			}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind bug

**What this PR does / why we need it**:
Currently a []byte type password will be fed to the configmap template, which will cause issue. Convert it to a string fix it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1084 

**Special notes for your reviewer**:
This pr fix the issue, however, I don't think use the trick(encoding/json treats []byte as b64 encoded) to do a base64 decoding and hide it from the coder is a good thing. Maybe use a string type like audi-api is a better way?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

