### PR TITLE
fix(platform): fix metrics for kube-scheduler

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/kubeadm.go
+++ b/pkg/platform/provider/baremetal/cluster/kubeadm.go
@@ -253,6 +253,7 @@ func (p *Provider) getControllerManagerExtraArgs(c *v1.Cluster) map[string]strin
 	args := map[string]string{
 		"allocate-node-cidrs": "true",
 		"cluster-cidr":        c.Spec.ClusterCIDR,
+		"bind-address":        "0.0.0.0",
 	}
 	if c.Spec.Features.IPv6DualStack {
 		args["node-cidr-mask-size-ipv4"] = fmt.Sprintf("%v", c.Status.NodeCIDRMaskSizeIPv4)
@@ -280,6 +281,7 @@ func (p *Provider) getSchedulerExtraArgs(c *v1.Cluster) map[string]string {
 	args := map[string]string{
 		"use-legacy-policy-config": "true",
 		"policy-config-file":       constants.KubernetesSchedulerPolicyConfigFile,
+		"bind-address":             "0.0.0.0",
 	}
 	for k, v := range c.Spec.SchedulerExtraArgs {
 		args[k] = v


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind bug

**What this PR does / why we need it**:
1. update `EnsurePatchAnnotation` to a safe way to patch annotation, now we don't need to check the kubeadm's version.
2. update to use secure-port for kube-scheduler and kube-controller-manager
3. set `bind-address` of kube-scheduler and kube-controller-manager to `0.0.0.0` by default. Then prometheus could scrape metrics through host IP.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1353 

**Special notes for your reviewer**:
tested on 1.20.4-tke.1, 1.19.7, 1.18.3, 1.17.13, 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

