### PR TITLE
fix(monitor): add node_role label for k8s_node_status_ready

### DIFF
--- a/pkg/monitor/controller/prometheus/yamls.go
+++ b/pkg/monitor/controller/prometheus/yamls.go
@@ -681,7 +681,7 @@ groups:
     expr: max(kube_node_status_condition{condition="Ready", status="true"} * on (node) group_left(node_role, device_type)  kube_node_labels)  without(condition, status)
 
   - record: k8s_node_status_ready
-    expr: max(kube_node_status_condition{condition="Ready", status="true"})  without(condition, status)
+    expr: max(kube_node_status_condition{condition="Ready", status="true"} * on (node) group_left(node_role, device_type)  kube_node_labels)  without(condition, status)
 
   - record: k8s_node_not_ready
     expr: max(kube_node_status_condition{condition="Ready", status="false"})  without(condition, status)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind bug


**What this PR does / why we need it**:
node_ready metrics chart in node monitoring is malfunctioning currently due to a lack of `node_role` label in `k8s_node_status_ready`. This pr will fix it by add node_role label to `k8s_node_status_ready`.
QL use in chart:
```sql
SELECT max(value) AS k8s_node_status_ready FROM global.autogen.k8s_node_status_ready WHERE node_role = 'Node' AND time >= '2021-06-10 05:58:52' AND time < '2021-06-10 06:58:52' GROUP BY time(1m), node
```
record in influxdb(before pr):
 time        |        __name__        |         cluster_display_name   |  cluster_id | node    |   prometheus    |     prometheus_replica | tenant_id | value 
--- | --- | --- | --- | --- | --- | ---| ---| ---
 1623133420405000000 |   k8s_node_status_ready| TKE     |                global    |    *****   |         kube-system/k8s  |  prometheus-k8s-0   |   default   |   1 

record in influxdb(after pr):
time           |         __name__      |            cluster_display_name  |   cluster_id | node      |       node_role   |  prometheus    |      prometheus_replica   |  tenant_id   |  value
--- | --- | --- | --- | --- | --- | ---| ---| ---| ---
1623307900405000000 |  k8s_node_status_ready  | TKE        |            global  |     *****  | Node    |    kube-system/k8s  | prometheus-k8s-0   |  default   |  1


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1355 

**Special notes for your reviewer**:
Currently I just copy the rule from 'k8s_node_status_ready_with_node_role', please check if it will affect something else.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

