### PR TITLE
fix(platform): add cbs sidecar and controller images

### DIFF
--- a/pkg/platform/provider/baremetal/phases/csioperator/images/images.go
+++ b/pkg/platform/provider/baremetal/phases/csioperator/images/images.go
@@ -28,11 +28,28 @@ import (
 
 const (
 	// LatestVersion is latest version of addon.
+	// TODO: bump up to v1.0.3
 	LatestVersion = "v1.0.2"
+
+	// Provisioner and ... csi sidecar and controller images name
+	Provisioner      = "csi-provisioner"
+	Attacher         = "csi-attacher"
+	Snapshotter      = "csi-snapshotter"
+	CSINodeRegistrar = "csi-node-driver-registrar"
+	TencentCBSDriver = "csi-tencentcloud-cbs"
 )
 
 type Components struct {
 	CSIOperator containerregistry.Image
+
+	// csi sidecar images
+	ProvisionerV101   containerregistry.Image
+	AttacherV110      containerregistry.Image
+	SnapshotterV110   containerregistry.Image
+	NodeRegistrarV110 containerregistry.Image
+
+	// Tencent CBS V1 && V1P1
+	CbsDriverV100 containerregistry.Image // TODO: v1.0.0 is DEPRECATING
 }
 
 func (c Components) Get(name string) *containerregistry.Image {
@@ -48,7 +65,14 @@ func (c Components) Get(name string) *containerregistry.Image {
 
 var versionMap = map[string]Components{
 	LatestVersion: {
+		// TODO: bump up to v1.0.3
 		CSIOperator: containerregistry.Image{Name: "csi-operator", Tag: "v1.0.2"},
+
+		ProvisionerV101:   containerregistry.Image{Name: Provisioner, Tag: "v1.0.1"},
+		AttacherV110:      containerregistry.Image{Name: Attacher, Tag: "v1.1.0"},
+		SnapshotterV110:   containerregistry.Image{Name: Snapshotter, Tag: "v1.1.0"},
+		NodeRegistrarV110: containerregistry.Image{Name: CSINodeRegistrar, Tag: "v0.3.0"},
+		CbsDriverV100:     containerregistry.Image{Name: TencentCBSDriver, Tag: "v1.0.0"},
 	},
 }
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

CSI-Operator need storage controller and sidecar images in local.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1414 

**Special notes for your reviewer**:

Given in other storage images couldn't be  accessible ,this PR only support TencentCBS V1. 

```sh
# images added
csi-tencentcloud-cbs:v1.0.0
csi-provisioner:v1.0.1
csi-attacher:v1.1.0
csi-snapshotter:v1.1.0
csi-node-driver-registrar:v1.1.0
```

If tke stack need support all the storage system in the feature, we need all the dependent images.And the [code  modification](https://github.com/TomatoAres/tke/commit/5d8ad72c3bd8fdcc08cc350d9ea5afdeeb7f54be) is complete.

```sh
# images needed in the feature
cephfsplugin:v0.3.0
cephfsplugin:v1.0.0
csi-attacher:v0.4.2
csi-provisioner:v0.4.2
csi-resizer:0.5.0
csi-snapshotter:v0.4.1
csi-tencentcloud-cbs:v0.2.1
csi-tencentcloud-cbs:v1.2.0
driver-registrar:v0.3.0
livenessprobe:v0.4.1
rbdplugin:v0.3.0
rbdplugin:v1.0.0
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

