### PR TITLE
fix(platform): upgrade addon description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations under the License.
 
 .PHONY: all
-all: lint test build
+all: asset lint test build
 
 # ==============================================================================
 # Build options


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

Fixes #1416 

**Special notes for your reviewer**:

The addon descriptions  orignal files is under `hack/addon/readme`.

Once we update or add files there, we need to excute `make asset` to generate some [assets code](https://github.com/tkestack/tke/tree/master/pkg/platform/registry/clusteraddontype/assets) with those static rescoures.  



