### PR TITLE
fix(platform): add csi-operator sidecar and controller images

### DIFF
--- a/hack/addon/readme/CSIOperator.md
+++ b/hack/addon/readme/CSIOperator.md
@@ -1,6 +1,6 @@
 # CSIOperator
 
-## CSIOperator 介绍 
+## CSIOperator 介绍
 
 Container Storage Interface Operator(CSIOperator)用于部署和更新 Kubernetes 集群中的 CSI 驱动和外部存储组件。
 
@@ -30,6 +30,27 @@ CSIOperator 用于支持集群方便的使用存储资源，当前支持的存�
 ![新建组件](images/新建扩展组件.png)
 4. 在弹出的扩展组件列表里，滑动列表窗口找到 CSIOperator
 5. 单击【完成】进行安装
+
+### 镜像准备
+
+当前支持的存储插件包括 RBD、CephFS、TencentCBS 和 TencentCFS（测试中，暂不支持），
+针对不同的模式，依赖不同的 csi 镜像
+
+由于支持版本较多，所有镜像都上传的话导致 `TKE Stack` 安装包太大，并且大部分并不会被使用，
+因此 所有镜像均已上传 [公网 dockerhub](https://hub.docker.com/u/tkestack):
+
+| csi 类型及版本 |依赖的镜像及拉取命令|
+|--------------|--------|
+| CephRBD V0 |docker pull tkestack/csi-provisioner:v0.4.2 <br>docker pull tkestack/csi-attacher:v0.4.2 <br>docker pull tkestack/csi-snapshotter:v0.4.1 <br/>docker pull tkestack/livenessprobe:v0.4.1 <br/>docker pull tkestack/driver-registrar:v0.3.0 <br/>docker pull tkestack/rbdplugin:v0.3.0|
+| CephRBD V1 |docker pull tkestack/csi-provisioner:v1.0.1 <br>docker pull tkestack/csi-attacher:v1.1.0<br>docker pull tkestack/csi-snapshotter:v1.1.0 <br/>docker pull tkestack/livenessprobe:v1.1.0<br/>docker pull tkestack/csi-node-driver-registrar:v1.1.0 <br/>docker pull tkestack/rbdplugin:v1.0.0|
+| CephFS V0 |docker pull tkestack/csi-provisioner:v0.4.2 <br>docker pull tkestack/csi-attacher:v0.4.2 <br>docker pull tkestack/livenessprobe:v0.4.1 <br/>docker pull tkestack/driver-registrar:v0.3.0 <br/>docker pull tkestack/cephfsplugin:v0.3.0|
+| CephFS V1 |docker pull tkestack/csi-provisioner:v1.0.1 <br/>docker pull tkestack/csi-attacher:v1.1.0<br/>docker pull tkestack/livenessprobe:v1.1.0<br/>docker pull tkestack/csi-node-driver-registrar:v1.1.0<br/>docker pull tkestack/cephfsplugin:v1.0.0|
+| TencentCBS V0 |docker pull tkestack/csi-provisioner:v1.0.1 <br/>docker pull tkestack/csi-attacher:v1.1.0<br/>docker pull tkestack/driver-registrar:v0.3.0<br/>docker pull tkestack/csi-tencentcloud-cbs:v0.2.1|
+| TencentCBS V1 |docker pull tkestack/csi-provisioner:v1.2.0 <br/>docker pull tkestack/csi-attacher:v1.1.0<br/>docker pull tkestack/csi-snapshotter:v1.2.2<br/>docker pull tkestack/csi-node-driver-registrar:v1.1.0<br/>docker pull tkestack/csi-tencentcloud-cbs:v1.0.0 <br />docker pull tkestack/csi-resizer:v0.5.0|
+| TencentCBS V1P1 |docker pull tkestack/csi-provisioner:v1.2.0 <br/>docker pull tkestack/csi-attacher:v1.1.0<br/>docker pull tkestack/csi-snapshotter:v1.2.2<br/>docker pull tkestack/csi-node-driver-registrar:v1.1.0<br/>docker pull tkestack/csi-tencentcloud-cbs:v1.2.0 <br />docker pull tkestack/csi-resizer:v0.5.0|
+
+
+使用时 `csi-operator`根据配置的存储类型拉取所需的镜像
 
 ### 通过 CSIOperator 使用腾讯云存储资源
 1. 登录 TKEStack
@@ -91,5 +112,4 @@ CSIOperator 用于支持集群方便的使用存储资源，当前支持的存�
 
 
 详情请见 [CSIOperator Example](https://github.com/tkestack/csi-operator/blob/master/examples)
-
 

--- a/pkg/platform/controller/addon/storage/csioperator/controller.go
+++ b/pkg/platform/controller/addon/storage/csioperator/controller.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/csioperator/images"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -40,14 +38,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
 	clientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformv1informer "tkestack.io/tke/api/client/informers/externalversions/platform/v1"
 	platformv1lister "tkestack.io/tke/api/client/listers/platform/v1"
 	v1 "tkestack.io/tke/api/platform/v1"
 	controllerutil "tkestack.io/tke/pkg/controller"
 	storageutil "tkestack.io/tke/pkg/platform/controller/addon/storage/util"
+	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/csioperator/images"
 	"tkestack.io/tke/pkg/platform/util"
-	containerregistryutil "tkestack.io/tke/pkg/util/containerregistry"
 	"tkestack.io/tke/pkg/util/log"
 	"tkestack.io/tke/pkg/util/metrics"
 )
@@ -64,6 +63,9 @@ const (
 
 	timeOut       = 5 * time.Minute
 	maxRetryCount = 5
+
+	// CSIRepo link to internet docker hub, where stores all csi depends images.
+	CSIRepo = "tkestack"
 )
 
 // Controller is responsible for performing actions dependent upon a CSIOperator phase.
@@ -614,7 +616,7 @@ func genContainerArgs(svInfo *storageutil.SVInfo) []string {
 	args := []string{
 		"--leader-election=true",
 		"--kubelet-root-dir=/var/lib/kubelet",
-		"--registry-domain=" + containerregistryutil.GetPrefix(),
+		"--registry-domain=" + CSIRepo,
 		"--logtostderr=true",
 		"--v=5",
 	}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

CSI-Operator need storage controller and sidecar images in local docker registry.

**Which issue(s) this PR fixes**:

Fixes #1414 

**Special notes for your reviewer**:

1. Need push this images to docker hub:

```sh
# images needed in the feature
cephfsplugin:v0.3.0
cephfsplugin:v1.0.0
csi-attacher:v0.4.2
csi-provisioner:v0.4.2
csi-resizer:v0.5.0
csi-snapshotter:v0.4.1
csi-tencentcloud-cbs:v0.2.1
csi-tencentcloud-cbs:v1.2.0
driver-registrar:v0.3.0
livenessprobe:v0.4.1
rbdplugin:v0.3.0
rbdplugin:v1.0.0
```

2. **NOTE:** Stack now use a old version csi-operator image (ID sha256:b77952b83730), which only looks like v1.0.2. 
Version of driver in this image is v1.0.0 but [the version in csi-operator code is v1.2.0](https://github.com/tkestack/csi-operator/blob/74188bd0f7462446109ee82f7488d8bd3646f525/pkg/controller/csi/enhancer/enhancer.go#L115). 

    We decide to use the old version, and remember to bump csi-operator up to v1.0.3 to fix this issue.

3. Close the old  #1419 



