### PR TITLE
fix(installer, registry): add s3 storage backend for registry

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1454,8 +1454,7 @@ func (t *TKE) prepareBaremetalProviderConfig(ctx context.Context) error {
 	}
 	if t.Para.Config.Registry.ThirdPartyRegistry == nil &&
 		t.Para.Config.Registry.TKERegistry != nil {
-		ip := t.Cluster.Spec.Machines[0].IP // registry current only run in first node
-		providerConfig.Registry.IP = ip
+		providerConfig.Registry.IP = t.Para.RegistryIP()
 	}
 	if t.auditEnabled() {
 		providerConfig.Audit.Address = t.determineGatewayHTTPSAddress()
@@ -2137,6 +2136,16 @@ func (t *TKE) installTKERegistryAPI(ctx context.Context) error {
 		"HarborEnabled":  t.Para.Config.Registry.TKERegistry.HarborEnabled,
 		"HarborCAFile":   t.Para.Config.Registry.TKERegistry.HarborCAFile,
 	}
+	//check if s3 enabled
+	storageConfig := t.Para.Config.Registry.TKERegistry.Storage
+	s3Enabled := (storageConfig != nil && storageConfig.S3 != nil)
+	options["S3Enabled"] = s3Enabled
+	if s3Enabled {
+		options["S3Storage"] = storageConfig.S3
+	}
+	//or enable filesystem by default
+	options["FilesystemEnabled"] = !s3Enabled
+
 	if t.Para.Config.Auth.OIDCAuth != nil {
 		options["OIDCClientID"] = t.Para.Config.Auth.OIDCAuth.ClientID
 		options["OIDCIssuerURL"] = t.Para.Config.Auth.OIDCAuth.IssuerURL
@@ -2163,18 +2172,28 @@ func (t *TKE) installTKERegistryController(ctx context.Context) error {
 		return err
 	}
 
-	err = apiclient.CreateResourceWithDir(ctx, t.globalClient, "manifests/tke-registry-controller/*.yaml",
-		map[string]interface{}{
-			"Replicas":           t.Config.Replicas,
-			"Image":              images.Get().TKERegistryController.FullName(),
-			"NodeName":           node.Name,
-			"AdminUsername":      t.Para.Config.Registry.TKERegistry.Username,
-			"AdminPassword":      string(t.Para.Config.Registry.TKERegistry.Password),
-			"EnableAuth":         t.Para.Config.Auth.TKEAuth != nil,
-			"EnableBusiness":     t.businessEnabled(),
-			"DomainSuffix":       t.Para.Config.Registry.TKERegistry.Domain,
-			"DefaultChartGroups": defaultChartGroupsStringConfig,
-		})
+	options := map[string]interface{}{
+		"Replicas":           t.Config.Replicas,
+		"Image":              images.Get().TKERegistryController.FullName(),
+		"NodeName":           node.Name,
+		"AdminUsername":      t.Para.Config.Registry.TKERegistry.Username,
+		"AdminPassword":      string(t.Para.Config.Registry.TKERegistry.Password),
+		"EnableAuth":         t.Para.Config.Auth.TKEAuth != nil,
+		"EnableBusiness":     t.businessEnabled(),
+		"DomainSuffix":       t.Para.Config.Registry.TKERegistry.Domain,
+		"DefaultChartGroups": defaultChartGroupsStringConfig,
+	}
+	//check if s3 enabled
+	storageConfig := t.Para.Config.Registry.TKERegistry.Storage
+	s3Enabled := (storageConfig != nil && storageConfig.S3 != nil)
+	options["S3Enabled"] = s3Enabled
+	if s3Enabled {
+		options["S3Storage"] = storageConfig.S3
+	}
+	//or enable filesystem by default
+	options["FilesystemEnabled"] = !s3Enabled
+
+	err = apiclient.CreateResourceWithDir(ctx, t.globalClient, "manifests/tke-registry-controller/*.yaml", options)
 	if err != nil {
 		return err
 	}

--- a/cmd/tke-installer/app/installer/manifests/tke-registry-api/tke-registry-api.yaml
+++ b/cmd/tke-installer/app/installer/manifests/tke-registry-api/tke-registry-api.yaml
@@ -56,8 +56,10 @@ spec:
               mountPath: /app/certs
             - name: tke-registry-api-volume
               mountPath: /app/conf
+{{- if .FilesystemEnabled }}
             - name: registry-data
               mountPath: /storage
+{{- end }}
             - name: tke-registry-api-secret
               mountPath: /etc/registry
           ports:
@@ -83,7 +85,9 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+{{- if .FilesystemEnabled }}
       nodeName: {{ .NodeName }}
+{{- end }}
       volumes:
         - name: certs-volume
           configMap:
@@ -91,10 +95,12 @@ spec:
         - name: tke-registry-api-volume
           configMap:
             name: tke-registry-api
+{{- if .FilesystemEnabled }}
         - name: registry-data
           hostPath:
             path: /var/lib/tke-registry-api
             type: DirectoryOrCreate
+{{- end }}
         - name: tke-registry-api-secret
           secret:
             secretName: tke-registry-api
@@ -201,8 +207,65 @@ data:
         endpoints:
         - "https://etcd.kube-system:2379"
         prefix: "/chart_backend_bucket"
+{{- if .FilesystemEnabled }}
       fileSystem:
         rootDirectory: /storage
+{{- end }}
+{{- if .S3Enabled }}
+{{- with .S3Storage }}
+      s3:
+        bucket: {{ .Bucket }}
+        region: {{ .Region }}
+{{- if .AccessKey }}
+        accessKey: {{ .AccessKey }}
+{{- end }}
+{{- if .SecretKey }}
+        secretKey: {{ .SecretKey }}
+{{- end }}
+{{- if .RegionEndpoint }}
+        regionEndpoint: {{ .RegionEndpoint }}
+{{- end }}
+{{- if .Encrypt }}
+        encrypt: {{ .Encrypt }}
+{{- end }}
+{{- if .KeyID }}
+        keyID: {{ .KeyID }}
+{{- end }}
+{{- if .Secure }}
+        secure: {{ .Secure }}
+{{- end }}
+{{- if .SkipVerify }}
+        skipVerify: {{ .SkipVerify }}
+{{- end }}
+{{- if .V4Auth }}
+        v4Auth: {{ .V4Auth }}
+{{- end }}
+{{- if .ChunkSize }}
+        chunkSize: {{ .ChunkSize }}
+{{- end }}
+{{- if .MultipartCopyChunkSize }}
+        multipartCopyChunkSize: {{ .MultipartCopyChunkSize }}
+{{- end }}
+{{- if .MultipartCopyMaxConcurrency }}
+        multipartCopyMaxConcurrency: {{ .MultipartCopyMaxConcurrency }}
+{{- end }}
+{{- if .MultipartCopyThresholdSize }}
+        multipartCopyThresholdSize: {{ .MultipartCopyThresholdSize }}
+{{- end }}
+{{- if .RootDirectory }}
+        rootDirectory: {{ .RootDirectory }}
+{{- end }}
+{{- if .StorageClass }}
+        storageClass: {{ .StorageClass }}
+{{- end }}
+{{- if .UserAgent }}
+        userAgent: {{ .UserAgent }}
+{{- end }}
+{{- if .ObjectACL }}
+        objectACL: {{ .ObjectACL }}
+{{- end }}
+{{- end -}}
+{{- end }}
       delete:
         enabled: true
     security:

--- a/cmd/tke-installer/app/installer/manifests/tke-registry-controller/tke-registry-controller.yaml
+++ b/cmd/tke-installer/app/installer/manifests/tke-registry-controller/tke-registry-controller.yaml
@@ -54,7 +54,9 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+{{- if .FilesystemEnabled }}
       nodeName: {{ .NodeName }}
+{{- end }}
       volumes:
         - name: certs-volume
           configMap:
@@ -123,8 +125,67 @@ data:
         endpoints:
         - "https://etcd.kube-system:2379"
         prefix: "/chart_backend_bucket"
+{{- if .FilesystemEnabled }}
       fileSystem:
         rootDirectory: /storage
+{{- end }}
+{{- if .S3Enabled }}
+{{- with .S3Storage }}
+      s3:
+        bucket: {{ .Bucket }}
+        region: {{ .Region }}
+{{- if .AccessKey }}
+        accessKey: {{ .AccessKey }}
+{{- end }}
+{{- if .SecretKey }}
+        secretKey: {{ .SecretKey }}
+{{- end }}
+{{- if .RegionEndpoint }}
+        regionEndpoint: {{ .RegionEndpoint }}
+{{- end }}
+{{- if .Encrypt }}
+        encrypt: {{ .Encrypt }}
+{{- end }}
+{{- if .KeyID }}
+        keyID: {{ .KeyID }}
+{{- end }}
+{{- if .Secure }}
+        secure: {{ .Secure }}
+{{- end }}
+{{- if .SkipVerify }}
+        skipVerify: {{ .SkipVerify }}
+{{- end }}
+{{- if .V4Auth }}
+        v4Auth: {{ .V4Auth }}
+{{- end }}
+{{- if .ChunkSize }}
+        chunkSize: {{ .ChunkSize }}
+{{- end }}
+{{- if .MultipartCopyChunkSize }}
+        multipartCopyChunkSize: {{ .MultipartCopyChunkSize }}
+{{- end }}
+{{- if .MultipartCopyMaxConcurrency }}
+        multipartCopyMaxConcurrency: {{ .MultipartCopyMaxConcurrency }}
+{{- end }}
+{{- if .MultipartCopyThresholdSize }}
+        multipartCopyThresholdSize: {{ .MultipartCopyThresholdSize }}
+{{- end }}
+{{- if .RootDirectory }}
+        rootDirectory: {{ .RootDirectory }}
+{{- end }}
+{{- if .StorageClass }}
+        storageClass: {{ .StorageClass }}
+{{- end }}
+{{- if .UserAgent }}
+        userAgent: {{ .UserAgent }}
+{{- end }}
+{{- if .ObjectACL }}
+        objectACL: {{ .ObjectACL }}
+{{- end }}
+{{- end -}}
+{{- end }}
+      delete:
+        enabled: true
     security:
       tokenPrivateKeyFile: /etc/registry/private_key.pem
       tokenPublicKeyFile: /etc/registry/public_key.crt

--- a/cmd/tke-installer/app/installer/types/types.go
+++ b/cmd/tke-installer/app/installer/types/types.go
@@ -32,6 +32,13 @@ type CreateClusterPara struct {
 	Config  Config     `json:"Config"`
 }
 
+func (c *CreateClusterPara) RegistryIP() string {
+	if c.Config.HA != nil {
+		return c.Config.HA.VIP()
+	}
+	return c.Cluster.Spec.Machines[0].IP
+}
+
 // Config is the installer config
 type Config struct {
 	Basic       *Basic       `json:"basic"`
@@ -138,12 +145,59 @@ func (r *Registry) IsOfficial() bool {
 }
 
 type TKERegistry struct {
-	Domain        string `json:"domain" validate:"hostname_rfc1123"`
-	HarborEnabled bool   `json:"harborEnabled"`
-	HarborCAFile  string `json:"harborCAFile"`
-	Namespace     string `json:"namespace"`
-	Username      string `json:"username"`
-	Password      []byte `json:"password"`
+	Domain        string              `json:"domain" validate:"hostname_rfc1123"`
+	HarborEnabled bool                `json:"harborEnabled"`
+	HarborCAFile  string              `json:"harborCAFile"`
+	Namespace     string              `json:"namespace"`
+	Username      string              `json:"username"`
+	Password      []byte              `json:"password"`
+	Storage       *TKERegistryStorage `json:"storage"`
+}
+
+type TKERegistryStorage struct {
+	Filesystem *TKERegistryFilesystemStorage `json:"filesystem"`
+	S3         *TKERegistryS3Storage         `json:"s3"`
+}
+
+type TKERegistryFilesystemStorage struct {
+}
+
+type TKERegistryS3Storage struct {
+	Bucket string `json:"bucket"`
+	Region string `json:"region"`
+
+	// +optional
+	AccessKey *string `json:"accessKey,omitempty"`
+	// +optional
+	SecretKey *string `json:"secretKey,omitempty"`
+	// +optional
+	RegionEndpoint *string `json:"regionEndpoint,omitempty"`
+	// +optional
+	Encrypt *bool `json:"encrypt,omitempty"`
+	// +optional
+	KeyID *string `json:"keyID,omitempty"`
+	// +optional
+	Secure *bool `json:"secure,omitempty"`
+	// +optional
+	SkipVerify *bool `json:"skipVerify,omitempty"`
+	// +optional
+	V4Auth *bool `json:"v4Auth,omitempty"`
+	// +optional
+	ChunkSize *int64 `json:"chunkSize,omitempty"`
+	// +optional
+	MultipartCopyChunkSize *int64 `json:"multipartCopyChunkSize,omitempty"`
+	// +optional
+	MultipartCopyMaxConcurrency *int64 `json:"multipartCopyMaxConcurrency,omitempty"`
+	// +optional
+	MultipartCopyThresholdSize *int64 `json:"multipartCopyThresholdSize,omitempty"`
+	// +optional
+	RootDirectory *string `json:"rootDirectory,omitempty"`
+	// +optional
+	StorageClass *string `json:"storageClass,omitempty"`
+	// +optional
+	UserAgent *string `json:"userAgent,omitempty"`
+	// +optional
+	ObjectACL *string `json:"objectACL,omitempty"`
 }
 
 type ThirdPartyRegistry struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Add s3 storage option for registry. Now users can choose to use s3 as distribution's backend in intaller's configuration.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1437

**Special notes for your reviewer**:
If a user choose s3 as registry backend, currently only docker images will be saved in the choosing storage as charts are stored in etcd by default. 

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

