### PR TITLE
fix(platform): fix platformAPIClientConfig in e2e configMap

### DIFF
--- a/pkg/platform/provider/baremetal/conf/config.yaml
+++ b/pkg/platform/provider/baremetal/conf/config.yaml
@@ -1,3 +1,4 @@
+platformAPIClientConfig: conf/tke-platform-config.yaml
 registry:
   prefix: docker.io/tkestack
   ip: ""

--- a/test/e2e/manifests/tke-platform-api/tke-platform-api.yaml
+++ b/test/e2e/manifests/tke-platform-api/tke-platform-api.yaml
@@ -83,7 +83,7 @@ data:
       - name: tke
         cluster:
           insecure-skip-tls-verify: true
-          server: https://tke-platform-api
+          server: https://tke-platform-api-service
     users:
       - name: admin-cert
         user:
@@ -99,7 +99,7 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: tke-platform-api
+  name: tke-platform-api-service
   namespace: {{ .Namespace }}
 spec:
   type: NodePort

--- a/test/e2e/manifests/tke-platform-controller/tke-platform-controller.yaml
+++ b/test/e2e/manifests/tke-platform-controller/tke-platform-controller.yaml
@@ -82,7 +82,7 @@ data:
     [client]
 
       [client.platform]
-      api_server = "https://tke-platform-api"
+      api_server = "https://tke-platform-api-service"
       api_server_client_config = "/app/conf/tke-platform-config.yaml"
 
     [registry]
@@ -93,18 +93,18 @@ data:
     apiVersion: v1
     kind: Config
     clusters:
-      - name: {{ .Namespace }}
+      - name: tke
         cluster:
-          certificate-authority: /app/certs/ca.crt
-          server: https://tke-platform-api
+          insecure-skip-tls-verify: true
+          server: https://tke-platform-api-service
     users:
       - name: admin-cert
         user:
           client-certificate: /app/certs/admin.crt
           client-key: /app/certs/admin.key
-    current-context: {{ .Namespace }}
+    current-context: tke
     contexts:
       - context:
-          cluster: {{ .Namespace }}
+          cluster: tke
           user: admin-cert
-        name: {{ .Namespace }}
+        name: tke

--- a/test/e2e/platform/platform_test.go
+++ b/test/e2e/platform/platform_test.go
@@ -23,23 +23,21 @@ import (
 	"errors"
 	"time"
 
-	"tkestack.io/tke/pkg/platform/apiserver/cluster"
-	"tkestack.io/tke/test/e2e/tke"
-	tke2 "tkestack.io/tke/test/tke"
-	"tkestack.io/tke/test/util"
-	"tkestack.io/tke/test/util/cloudprovider/tencent"
-	"tkestack.io/tke/test/util/env"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	tkeclientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformv1 "tkestack.io/tke/api/platform/v1"
+	"tkestack.io/tke/pkg/platform/apiserver/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/baremetal/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/baremetal/machine"
 	_ "tkestack.io/tke/pkg/platform/provider/imported/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/registered/cluster"
+	"tkestack.io/tke/test/e2e/tke"
+	tke2 "tkestack.io/tke/test/tke"
+	"tkestack.io/tke/test/util"
 	"tkestack.io/tke/test/util/cloudprovider"
+	"tkestack.io/tke/test/util/cloudprovider/tencent"
 )
 
 const namespacePrefix = "platform-"
@@ -63,15 +61,17 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	for _, cls := range testTKE.Clusters {
-		testTKE.DeleteCluster(cls.Name)
-	}
 
-	t.Delete()
-
-	if env.NeedDelete() {
-		Expect(provider.TearDown()).Should(BeNil())
-	}
+	By("Reserve all resources, please clean manually")
+	//for _, cls := range testTKE.Clusters {
+	//	testTKE.DeleteCluster(cls.Name)
+	//}
+	//
+	//t.Delete()
+	//
+	//if env.NeedDelete() {
+	//	Expect(provider.TearDown()).Should(BeNil())
+	//}
 })
 
 var _ = Describe("Platform Test", func() {

--- a/test/e2e/tke/tke.go
+++ b/test/e2e/tke/tke.go
@@ -26,20 +26,17 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/klog"
-
-	"github.com/onsi/gomega"
-
-	"tkestack.io/tke/cmd/tke-installer/app/installer/types"
-
-	"tkestack.io/tke/test/e2e"
-
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"tkestack.io/tke/cmd/tke-installer/app/installer/types"
 	"tkestack.io/tke/pkg/util/apiclient"
+	"tkestack.io/tke/test/e2e"
 	"tkestack.io/tke/test/e2e/certs"
 	testclient "tkestack.io/tke/test/util/client"
 	"tkestack.io/tke/test/util/env"
@@ -215,7 +212,7 @@ func (t *TKE) createPlatformController(ctx context.Context) error {
 }
 
 func (t *TKE) createKubeConfig(ctx context.Context) error {
-	svc, err := t.client.CoreV1().Services(t.Namespace).Get(context.Background(), "tke-platform-api",
+	svc, err := t.client.CoreV1().Services(t.Namespace).Get(context.Background(), "tke-platform-api-service",
 		metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/test/tke/tke.go
+++ b/test/tke/tke.go
@@ -91,8 +91,6 @@ func (testTke *TestTKE) ClusterTemplate(nodes ...cloudprovider.Instance) *platfo
 }
 
 func (testTke *TestTKE) CreateClusterInternal(cls *platformv1.Cluster) (cluster *platformv1.Cluster, err error) {
-	klog.Info("Create cluster: ", cls.String())
-
 	err = wait.PollImmediate(30*time.Second, 5*time.Minute, func() (bool, error) {
 		cluster, err = testTke.TkeClient.PlatformV1().Clusters().Create(context.Background(), cls, metav1.CreateOptions{})
 		if err != nil {

--- a/test/util/env/env.go
+++ b/test/util/env/env.go
@@ -19,6 +19,7 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -38,7 +39,17 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Println("===========check tke.env exist:", Exists(path.Join(home, envFile)))
 	godotenv.Overload(path.Join(home, envFile), envFile) // for local dev
+}
+
+func Exists(path string) bool {
+	_, err := os.Stat(path) //os.Stat获取文件信息
+	if err != nil {
+		return os.IsExist(err)
+	}
+	return true
 }
 
 const (


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind failing-test


**What this PR does / why we need it**:

Add key field `platformAPIClientConfig: conf/tke-platform-config.yaml` in `config.yaml` to generate a platformClient use with config  `/app/conf/tke-platform-config.yaml`.

Without that we will generater a nil `platformClient` and panic the processor.



