### PR TITLE
fix(platform): test e2e failed

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/provider.go
+++ b/pkg/platform/provider/baremetal/cluster/provider.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/client-go/tools/clientcmd"
+
 	platformv1client "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
 	"tkestack.io/tke/api/platform"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/config"
@@ -179,7 +180,6 @@ func NewProvider() (*Provider, error) {
 			}
 		}
 	}
-
 	return p, nil
 }
 

--- a/pkg/platform/provider/baremetal/conf/config.yaml
+++ b/pkg/platform/provider/baremetal/conf/config.yaml
@@ -1,3 +1,4 @@
+platformAPIClientConfig: conf/tke-platform-config.yaml
 registry:
   prefix: docker.io/tkestack
   ip: ""

--- a/pkg/platform/provider/baremetal/validation/cluster.go
+++ b/pkg/platform/provider/baremetal/validation/cluster.go
@@ -24,12 +24,13 @@ import (
 	"net"
 	"strings"
 
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"tkestack.io/tke/api/platform"
-
 	netutils "k8s.io/utils/net"
+
 	platformv1client "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
+	"tkestack.io/tke/api/platform"
 	platformv1 "tkestack.io/tke/api/platform/v1"
 	csioperatorimage "tkestack.io/tke/pkg/platform/provider/baremetal/phases/csioperator/images"
 	"tkestack.io/tke/pkg/platform/provider/baremetal/phases/gpu"
@@ -38,6 +39,7 @@ import (
 	vendor "tkestack.io/tke/pkg/platform/util/kubevendor"
 	"tkestack.io/tke/pkg/spec"
 	"tkestack.io/tke/pkg/util/ipallocator"
+	"tkestack.io/tke/pkg/util/log"
 	"tkestack.io/tke/pkg/util/validation"
 	utilvalidation "tkestack.io/tke/pkg/util/validation"
 )
@@ -98,15 +100,26 @@ func ValidateClusterSpecVersion(platformClient platformv1client.PlatformV1Interf
 }
 
 func getK8sValidVersions(platformClient platformv1client.PlatformV1Interface, clsName string) (validVersions []string, err error) {
-	k8sValidVersions := []string{}
 	if clsName == "global" || platformClient == nil {
 		return spec.K8sVersions, nil
 	}
-	client, err := util.BuildExternalClientSetWithName(context.Background(), platformClient, "global")
+
+	cluster, err := platformClient.Clusters().Get(context.Background(), "global", metav1.GetOptions{})
 	if err != nil {
-		return k8sValidVersions, err
+		if k8serror.IsNotFound(err) {
+			log.Warnf("global cluster is not exist")
+
+			return spec.K8sVersions, nil
+		}
+		return nil, err
 	}
-	_, k8sValidVersions, err = util.GetPlatformVersionsFromClusterInfo(context.Background(), client)
+
+	client, err := util.BuildExternalClientSet(context.Background(), cluster, platformClient)
+	if err != nil {
+		return nil, err
+	}
+
+	_, k8sValidVersions, err := util.GetPlatformVersionsFromClusterInfo(context.Background(), client)
 
 	return k8sValidVersions, err
 }

--- a/test/e2e/manifests/tke-platform-api/tke-platform-api.yaml
+++ b/test/e2e/manifests/tke-platform-api/tke-platform-api.yaml
@@ -83,7 +83,7 @@ data:
       - name: tke
         cluster:
           insecure-skip-tls-verify: true
-          server: https://tke-platform-api
+          server: https://tke-platform-api.{{ .Namespace }}
     users:
       - name: admin-cert
         user:

--- a/test/e2e/platform/platform_test.go
+++ b/test/e2e/platform/platform_test.go
@@ -23,23 +23,23 @@ import (
 	"errors"
 	"time"
 
-	"tkestack.io/tke/pkg/platform/apiserver/cluster"
-	"tkestack.io/tke/test/e2e/tke"
-	tke2 "tkestack.io/tke/test/tke"
-	"tkestack.io/tke/test/util"
-	"tkestack.io/tke/test/util/cloudprovider/tencent"
-	"tkestack.io/tke/test/util/env"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	tkeclientset "tkestack.io/tke/api/client/clientset/versioned"
 	platformv1 "tkestack.io/tke/api/platform/v1"
+	"tkestack.io/tke/pkg/platform/apiserver/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/baremetal/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/baremetal/machine"
 	_ "tkestack.io/tke/pkg/platform/provider/imported/cluster"
 	_ "tkestack.io/tke/pkg/platform/provider/registered/cluster"
+	"tkestack.io/tke/test/e2e/tke"
+	tke2 "tkestack.io/tke/test/tke"
+	"tkestack.io/tke/test/util"
 	"tkestack.io/tke/test/util/cloudprovider"
+	"tkestack.io/tke/test/util/cloudprovider/tencent"
+	"tkestack.io/tke/test/util/env"
 )
 
 const namespacePrefix = "platform-"

--- a/test/e2e/tke/tke.go
+++ b/test/e2e/tke/tke.go
@@ -26,20 +26,17 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/klog"
-
-	"github.com/onsi/gomega"
-
-	"tkestack.io/tke/cmd/tke-installer/app/installer/types"
-
-	"tkestack.io/tke/test/e2e"
-
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"tkestack.io/tke/cmd/tke-installer/app/installer/types"
 	"tkestack.io/tke/pkg/util/apiclient"
+	"tkestack.io/tke/test/e2e"
 	"tkestack.io/tke/test/e2e/certs"
 	testclient "tkestack.io/tke/test/util/client"
 	"tkestack.io/tke/test/util/env"


### PR DESCRIPTION
add namespace in kube config

**What type of PR is this?**

> /kind bug
> /kind failing-test

**What this PR does / why we need it**:

Without this pr:

1.  platfomClient  in tke-platform-controller will be nil
2. tke-platform-api pod will resolve tke-platformapi service with pod ip ranther than service ip
3. validating can not skip  checking spec.version with global cluster


