### PR TITLE
fix(platform): rm ensure mc label

### DIFF
--- a/pkg/platform/controller/machine/machine_controller.go
+++ b/pkg/platform/controller/machine/machine_controller.go
@@ -27,12 +27,10 @@ import (
 	"golang.org/x/time/rate"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 
 	platformversionedclient "tkestack.io/tke/api/client/clientset/versioned/typed/platform/v1"
@@ -47,7 +45,6 @@ import (
 	"tkestack.io/tke/pkg/util/apiclient"
 	"tkestack.io/tke/pkg/util/log"
 	"tkestack.io/tke/pkg/util/metrics"
-	"tkestack.io/tke/pkg/util/strategicpatch"
 )
 
 const (
@@ -231,9 +228,6 @@ func (c *Controller) syncMachine(key string) error {
 }
 
 func (c *Controller) reconcile(ctx context.Context, key string, machine *platformv1.Machine) error {
-
-	c.ensureSyncMachineNodeLabel(ctx, machine)
-
 	var err error
 	switch machine.Status.Phase {
 	case platformv1.MachineInitializing:
@@ -341,51 +335,4 @@ func (c *Controller) checkHealth(ctx context.Context, machine *platformv1.Machin
 	log.FromContext(ctx).Info("Update machine health status", "phase", machine.Status.Phase)
 
 	return machine
-}
-
-func (c *Controller) ensureSyncMachineNodeLabel(ctx context.Context, machine *platformv1.Machine) {
-
-	cluster, err := clusterprovider.GetV1ClusterByName(ctx, c.platformClient, machine.Spec.ClusterName, clusterprovider.AdminUsername)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "sync Machine node label error")
-		return
-	}
-
-	client, err := cluster.Clientset()
-	if err != nil {
-		log.FromContext(ctx).Error(err, "sync Machine node label error")
-		return
-	}
-
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := client.CoreV1().Nodes().Get(ctx, machine.Spec.IP, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		labels := node.GetLabels()
-		_, ok := labels[string(apiclient.LabelMachineIPV4)]
-		if ok {
-			return nil
-		}
-
-		oldNode := node.DeepCopy()
-		labels[string(apiclient.LabelMachineIPV4)] = machine.Spec.IP
-		node.SetLabels(labels)
-
-		patchBytes, err := strategicpatch.GetPatchBytes(oldNode, node)
-		if err != nil {
-			return fmt.Errorf("GetPatchBytes for node error: %w", err)
-		}
-
-		_, err = client.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-		return err
-	})
-
-	if err != nil {
-		log.FromContext(ctx).Error(err, "sync Machine node label error")
-	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/tkestack/tke/issues/1366

ref: https://github.com/tkestack/tke/blob/master/docs/design-proposals/hostname-as-nodename-support.md

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

