### PR TITLE
fix(platform): add needUpdate func in cluster/machine provider

### DIFF
--- a/pkg/platform/controller/machine/machine_controller.go
+++ b/pkg/platform/controller/machine/machine_controller.go
@@ -109,7 +109,14 @@ func (c *Controller) addMachine(obj interface{}) {
 func (c *Controller) updateMachine(old, obj interface{}) {
 	oldMachine := old.(*platformv1.Machine)
 	machine := obj.(*platformv1.Machine)
-	if !c.needsUpdate(oldMachine, machine) {
+
+	controllerNeedUpddateResult := c.needsUpdate(oldMachine, machine)
+	var providerNeedUpddateResult bool
+	provider, _ := machineprovider.GetProvider(machine.Spec.Type)
+	if provider != nil {
+		providerNeedUpddateResult = provider.NeedUpdate(oldMachine, machine)
+	}
+	if !(controllerNeedUpddateResult || providerNeedUpddateResult) {
 		return
 	}
 	c.log.Info("Updating machine", "machine", machine.Name)

--- a/pkg/platform/provider/cluster/interface.go
+++ b/pkg/platform/provider/cluster/interface.go
@@ -65,6 +65,8 @@ type ControllerProvider interface {
 	Setup() error
 	// Teardown called by controller for plugin do some clean job.
 	Teardown() error
+	// NeedUpdate could be implemented by user to judge whether cluster need update or not.
+	NeedUpdate(old, new *platformv1.Cluster) bool
 
 	OnCreate(ctx context.Context, cluster *v1.Cluster) error
 	OnUpdate(ctx context.Context, cluster *v1.Cluster) error
@@ -337,6 +339,10 @@ func (p *DelegateProvider) OnRunning(ctx context.Context, cluster *v1.Cluster) e
 
 func (p *DelegateProvider) OnFilter(ctx context.Context, cluster *platformv1.Cluster) (pass bool) {
 	return true
+}
+
+func (p *DelegateProvider) NeedUpdate(old, new *platformv1.Cluster) bool {
+	return false
 }
 
 func (p *DelegateProvider) getNextConditionType(conditionType string, handlers []Handler) string {

--- a/pkg/platform/provider/machine/interface.go
+++ b/pkg/platform/provider/machine/interface.go
@@ -51,7 +51,17 @@ const (
 type Provider interface {
 	Name() string
 
+	APIProvider
+	ControllerProvider
+}
+
+type APIProvider interface {
 	Validate(machine *platform.Machine) field.ErrorList
+}
+
+type ControllerProvider interface {
+	// NeedUpdate could be implemented by user to judge whether machine need update or not.
+	NeedUpdate(old, new *platformv1.Machine) bool
 
 	PreCreate(machine *platform.Machine) error
 	AfterCreate(machine *platform.Machine) error
@@ -211,6 +221,10 @@ func (p *DelegateProvider) OnDelete(ctx context.Context, machine *platformv1.Mac
 	cluster.Status.Message = ""
 
 	return nil
+}
+
+func (p *DelegateProvider) NeedUpdate(old, new *platformv1.Machine) bool {
+	return false
 }
 
 func (p *DelegateProvider) getNextConditionType(conditionType string) string {


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

User can define  customized `needUpdate` function in provider, default reture false.

**Which issue(s) this PR fixes**:

Fixes #1484 



