### PR TITLE
fix(Makefile): release lack of asset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ deploy:
 .PHONY: clean
 clean:
 	@$(MAKE) go.clean
+	git restore pkg/platform/registry/clusteraddontype/assets/assets.go
 
 ## lint: Check syntax and styling of go sources.
 .PHONY: lint
@@ -139,7 +140,7 @@ release.build:
 ifeq ($(NEED_BUILD_PROVIDER),true)
 	cd build/docker/tools/provider-res && make all
 endif
-	make push.multiarch
+	make asset && make push.multiarch
 
 ## release: Release tke
 .PHONY: release


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

Daily_build actions execute `make release.build`, 

but this command doesn't `make asset` by default, so I add `make asset`

If `NEED_BUILD_PROVIDER==true` or PR actions, we will make asset in #1421

**Which issue(s) this PR fixes**:

Fixes #1416

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

