### PR TITLE
feat(console): when cluster is containerd, disabled open logagent

### DIFF
--- a/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterDetailBasicInfoPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterDetailBasicInfoPanel.tsx
@@ -28,10 +28,11 @@ import { Clip } from '../../../../common/components';
 import { DialogNameEnum } from '../../../models';
 import { RootProps } from '../../ClusterApp';
 import { ClusterStatus } from '../../clusterManage/ClusterTablePanel';
+import { ContainerRuntimeEnum } from '@src/modules/cluster/constants/Config';
 
 export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> {
   render() {
-    let { cluster } = this.props;
+    const { cluster } = this.props;
 
     return (
       <FormPanel title={t('基本信息')}>
@@ -44,11 +45,11 @@ export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> 
     );
   }
   _renderNodeMax() {
-    let { cluster } = this.props;
-    let clusterInfo: Cluster = cluster.selection;
+    const { cluster } = this.props;
+    const clusterInfo: Cluster = cluster.selection;
     if (clusterInfo && clusterInfo.spec.clusterCIDR) {
-      let b = clusterInfo.spec.clusterCIDR.split('/')[1];
-      let { maxNodePodNum, maxClusterServiceNum } = clusterInfo.spec.properties;
+      const b = clusterInfo.spec.clusterCIDR.split('/')[1];
+      const { maxNodePodNum, maxClusterServiceNum } = clusterInfo.spec.properties;
       return Math.pow(2, 32 - parseInt(b)) / maxNodePodNum - Math.ceil(maxClusterServiceNum / maxNodePodNum);
     } else {
       return '';
@@ -56,8 +57,8 @@ export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> 
   }
   /** 处理开关日志采集组件的的操作 */
   private _handleSwitch(cluster: Cluster) {
-    let { actions, route } = this.props;
-    let enableLogAgent = !cluster.spec.logAgentName;
+    const { actions, route } = this.props;
+    const enableLogAgent = !cluster.spec.logAgentName;
     if (enableLogAgent) {
       actions.cluster.enableLogAgent(cluster);
     } else {
@@ -70,9 +71,9 @@ export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> 
   }
   /** 展示集群的基本信息 */
   private _renderClusterInfo() {
-    let { actions, cluster } = this.props;
-    let clusterInfo: Cluster = cluster.selection;
-    let nodeMax = this._renderNodeMax();
+    const { actions, cluster } = this.props;
+    const clusterInfo: Cluster = cluster.selection;
+    const nodeMax = this._renderNodeMax();
     return cluster.selection ? (
       <React.Fragment>
         <FormPanel.Item label={t('集群名称')} text>
@@ -88,6 +89,9 @@ export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> 
         </FormPanel.Item>
         <FormPanel.Item label={t('Kubernetes版本')} text>
           {clusterInfo.status.version}
+        </FormPanel.Item>
+        <FormPanel.Item label={t('运行时组件')} text>
+          {clusterInfo?.spec?.features?.enableContainerRuntime ?? ContainerRuntimeEnum.DOCKER}
         </FormPanel.Item>
         {clusterInfo.spec.networkDevice && (
           <FormPanel.Item label={t('网卡名称')} text>

--- a/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterPlugInfoPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterPlugInfoPanel.tsx
@@ -15,22 +15,24 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { FormPanel } from '@tencent/ff-component';
-import { Table, TableColumn, Button, Icon } from '@tea/component';
+import { Table, TableColumn, Button, Icon, Bubble } from '@tea/component';
 import { RootProps } from '../../ClusterApp';
 import { FetchState } from '@tencent/ff-redux';
 import { router } from '../../../router';
+import { ContainerRuntimeEnum } from '@src/modules/cluster/constants/Config';
 
 enum PlugType {
   Promethus,
   LogAgent
 }
 
-export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, clusterVersion, route }) => {
-  const targetCluster = cluster.selection;
-  const { promethus = null, logAgent = null } = targetCluster ? cluster.selection.spec : {};
-  const clusterId = targetCluster ? targetCluster.metadata.name : '';
+export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, route }) => {
+  const { promethus = null, logAgent = null } = cluster?.selection?.spec ?? {};
+  const clusterId = cluster?.selection?.metadata?.name ?? '';
+
+  const isContainerd = cluster?.selection?.spec?.features?.enableContainerRuntime === ContainerRuntimeEnum.CONTAINERD;
 
   const open = (type: PlugType) => () => {
     switch (type) {
@@ -66,6 +68,8 @@ export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, cl
       key: 'action',
       header: '操作',
       render({ action, type }) {
+        const disabled = type === PlugType.LogAgent && isContainerd;
+
         return action ? (
           <>
             <Button type="link" onClick={close(type)}>
@@ -73,9 +77,11 @@ export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, cl
             </Button>
           </>
         ) : (
-          <Button type="link" onClick={open(type)}>
-            开启
-          </Button>
+          <Bubble content={disabled ? '运行时为containerd的集群不支持开启日志采集' : ''}>
+            <Button type="link" disabled={disabled} onClick={open(type)}>
+              开启
+            </Button>
+          </Bubble>
         );
       }
     }
@@ -104,7 +110,12 @@ export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, cl
       {cluster.list.fetched !== true || cluster.list.fetchState === FetchState.Fetching ? (
         <Icon type="loading" />
       ) : (
-        <Table columns={columns} records={records} recordKey="des" />
+        <Table
+          columns={columns}
+          records={records}
+          recordKey="des"
+          rowDisabled={({ type }) => type === PlugType.LogAgent && isContainerd}
+        />
       )}
     </FormPanel>
   );

--- a/web/console/src/modules/common/models/Cluster.ts
+++ b/web/console/src/modules/common/models/Cluster.ts
@@ -15,6 +15,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+import { ContainerRuntimeEnum } from '@src/modules/cluster/constants/Config';
 import { Identifiable } from '@tencent/ff-redux';
 import { Resource } from './Resource';
 
@@ -56,6 +57,7 @@ interface ClusterSpec {
   features?: {
     ipvs: boolean;
     public: boolean;
+    enableContainerRuntime?: ContainerRuntimeEnum;
   };
 
   /** 集群类型 */


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
fix: https://github.com/tkestack/tke/issues/1536

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

