### PR TITLE
fix(console): should use spec.features.containerRuntime

### DIFF
--- a/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterDetailBasicInfoPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterDetailBasicInfoPanel.tsx
@@ -91,7 +91,7 @@ export class ClusterDetailBasicInfoPanel extends React.Component<RootProps, {}> 
           {clusterInfo.status.version}
         </FormPanel.Item>
         <FormPanel.Item label={t('运行时组件')} text>
-          {clusterInfo?.spec?.features?.enableContainerRuntime ?? ContainerRuntimeEnum.DOCKER}
+          {clusterInfo?.spec?.features?.containerRuntime ?? ContainerRuntimeEnum.DOCKER}
         </FormPanel.Item>
         {clusterInfo.spec.networkDevice && (
           <FormPanel.Item label={t('网卡名称')} text>

--- a/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterPlugInfoPanel.tsx
+++ b/web/console/src/modules/cluster/components/resource/clusterInfomation/ClusterPlugInfoPanel.tsx
@@ -32,7 +32,7 @@ export const ClusterPlugInfoPanel: React.FC<RootProps> = ({ cluster, actions, ro
   const { promethus = null, logAgent = null } = cluster?.selection?.spec ?? {};
   const clusterId = cluster?.selection?.metadata?.name ?? '';
 
-  const isContainerd = cluster?.selection?.spec?.features?.enableContainerRuntime === ContainerRuntimeEnum.CONTAINERD;
+  const isContainerd = cluster?.selection?.spec?.features?.containerRuntime === ContainerRuntimeEnum.CONTAINERD;
 
   const open = (type: PlugType) => () => {
     switch (type) {

--- a/web/console/src/modules/common/models/Cluster.ts
+++ b/web/console/src/modules/common/models/Cluster.ts
@@ -57,7 +57,7 @@ interface ClusterSpec {
   features?: {
     ipvs: boolean;
     public: boolean;
-    enableContainerRuntime?: ContainerRuntimeEnum;
+    containerRuntime?: ContainerRuntimeEnum;
   };
 
   /** 集群类型 */


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind feature


**What this PR does / why we need it**:
pr: https://github.com/tkestack/tke/pull/1549 使用了错误的字段`spec.features.enableContainerRuntime`来判断集群的运行时组件, 现修改为`spec.features.containerRuntime`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

