### PR TITLE
fix(installer): add request and limit resources for cilium workload

### DIFF
--- a/pkg/platform/provider/baremetal/manifests/cilium/cilium.yaml
+++ b/pkg/platform/provider/baremetal/manifests/cilium/cilium.yaml
@@ -496,6 +496,13 @@ spec:
                 - NET_ADMIN
                 - SYS_MODULE
             privileged: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
           volumeMounts:
             - mountPath: /sys/fs/bpf
               name: bpf-maps
@@ -560,7 +567,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 100Mi
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: cilium
@@ -703,6 +713,13 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
           volumeMounts:
             - mountPath: /tmp/cilium/config-map
               name: cilium-config-path

--- a/pkg/platform/provider/baremetal/manifests/cilium/eni-ipamd.yaml
+++ b/pkg/platform/provider/baremetal/manifests/cilium/eni-ipamd.yaml
@@ -200,7 +200,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 100Mi
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/pkg/platform/provider/baremetal/manifests/cilium/masq-agent.yaml
+++ b/pkg/platform/provider/baremetal/manifests/cilium/masq-agent.yaml
@@ -26,7 +26,13 @@ spec:
         - image: {{ .MasqImage }}
           imagePullPolicy: IfNotPresent
           name: ip-masq-agent
-          resources: {}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/pkg/platform/provider/baremetal/manifests/cilium/router.yaml
+++ b/pkg/platform/provider/baremetal/manifests/cilium/router.yaml
@@ -109,6 +109,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: cilium-router
           resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
             limits:
               cpu: 500m
               memory: 512Mi


### PR DESCRIPTION
> /kind bug

currently the request and limit resources weren't set in the manifests of the cilium workloads. this pull request is target to solve the issue.

Fixes #1312
