### PR TITLE
feat(platform): fix coredns version to 1.7.0

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/kubeadm.go
+++ b/pkg/platform/provider/baremetal/cluster/kubeadm.go
@@ -35,7 +35,6 @@ import (
 	v1 "tkestack.io/tke/pkg/platform/types/v1"
 	"tkestack.io/tke/pkg/util/apiclient"
 	"tkestack.io/tke/pkg/util/json"
-	"tkestack.io/tke/pkg/util/version"
 )
 
 func (p *Provider) getKubeadmInitConfig(c *v1.Cluster) *kubeadm.InitConfig {
@@ -182,6 +181,7 @@ func (p *Provider) getClusterConfiguration(c *v1.Cluster) *kubeadmv1beta2.Cluste
 		},
 		DNS: kubeadmv1beta2.DNS{
 			Type: kubeadmv1beta2.CoreDNS,
+			// fix coredns version to customize for all k8s version
 			ImageMeta: kubeadmv1beta2.ImageMeta{
 				ImageRepository: p.config.Registry.Prefix,
 				ImageTag:        images.Get().CoreDNS.Tag,
@@ -191,11 +191,6 @@ func (p *Provider) getClusterConfiguration(c *v1.Cluster) *kubeadmv1beta2.Cluste
 		ClusterName:     c.Name,
 		FeatureGates: map[string]bool{
 			"IPv6DualStack": c.Cluster.Spec.Features.IPv6DualStack},
-	}
-
-	// since k8s 1.19 will use offical coreDNS version
-	if version.Compare(c.Spec.Version, constants.NeedUpgradeCoreDNSK8sVersion) < 0 {
-		config.DNS.ImageTag = images.Get().CoreDNS.Tag
 	}
 
 	utilruntime.Must(json.Merge(&config.Etcd, &c.Spec.Etcd))

--- a/pkg/platform/provider/baremetal/cluster/provider.go
+++ b/pkg/platform/provider/baremetal/cluster/provider.go
@@ -145,7 +145,6 @@ func NewProvider() (*Provider, error) {
 		},
 		UpgradeHandlers: []clusterprovider.Handler{
 			p.EnsurePreClusterUpgradeHook,
-			p.EnsureUpgradeCoreDNS,
 			p.EnsureUpgradeControlPlaneNode,
 			p.EnsurePostClusterUpgradeHook,
 		},

--- a/pkg/platform/provider/baremetal/constants/constants.go
+++ b/pkg/platform/provider/baremetal/constants/constants.go
@@ -134,6 +134,4 @@ const (
 	MinNumCPU = 2
 
 	APIServerHostName = "api.tke.com"
-
-	NeedUpgradeCoreDNSK8sVersion = "1.19.0"
 )


### PR DESCRIPTION
kubeadm deploy cluster with 1.7.0 coredns;
upgrade EnsureUpgradeCoreDNS step is not necessary

**What type of PR is this?**

> /kind bug
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

hardcode coredns version 1.7.0 for all k8s version

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

