### PR TITLE
fix(console): when query value is empty ,url is wrong

### DIFF
--- a/web/console/helpers/urlUtil.ts
+++ b/web/console/helpers/urlUtil.ts
@@ -72,7 +72,8 @@ export const reduceK8sQueryString = ({
       // 也许value是object，即labelSelector 或者 fieldSelector
       value = isObject(value)
         ? Object.entries(value)
-            .map(([key, value]) => `${key}${value && '='}${value}`)
+            .filter(([_, value]) => value)
+            .map(([key, value]) => `${key}=${value}`)
             .join(',')
         : value;
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug


**What this PR does / why we need it**:
1、当query中某一项value为空时，会导致query部分拼接不符合请求规范，从而导致请求失败
**Which issue(s) this PR fixes**:
fix: https://github.com/tkestack/tke/issues/1634
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

