### PR TITLE
fix(monitor): cluster dynamic client is nil

### DIFF
--- a/pkg/monitor/util/cache/cache.go
+++ b/pkg/monitor/util/cache/cache.go
@@ -348,8 +348,9 @@ func NewCacher(platformClient platformversionedclient.PlatformV1Interface,
 
 func (c *cacher) getTApps(ctx context.Context, curDynamicClientSet util.DynamicClientSet, cluster string) int {
 	count := 0
-	if curDynamicClientSet == nil {
-		log.Warn("Query TApps failed", log.Any("cluster", cluster), log.Err(fmt.Errorf("DynamicClientSet is nil")))
+	if curDynamicClientSet[cluster] == nil {
+		log.Info("Query TApps failed", log.Any("cluster", cluster), log.Err(fmt.Errorf("DynamicClientSet is nil")))
+		return 0
 	}
 	content, err := curDynamicClientSet[cluster].Resource(TAppResource).
 		Namespace(AllNamespaces).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

