### PR TITLE
feat(platform): add not found proxy

### DIFF
--- a/cmd/tke-platform-api/app/config/config.go
+++ b/cmd/tke-platform-api/app/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	VersionedSharedInformerFactory versionedinformers.SharedInformerFactory
 	StorageFactory                 *serverstorage.DefaultStorageFactory
 	PrivilegedUsername             string
+	FeatureOptions                 *options.FeatureOptions
 }
 
 // CreateConfigFromOptions creates a running configuration instance based
@@ -124,5 +125,6 @@ func CreateConfigFromOptions(serverName string, opts *options.Options) (*Config,
 		VersionedSharedInformerFactory: versionedInformers,
 		StorageFactory:                 storageFactory,
 		PrivilegedUsername:             opts.Authentication.PrivilegedUsername,
+		FeatureOptions:                 opts.FeatureOptions,
 	}, nil
 }

--- a/cmd/tke-platform-api/app/options/feature.go
+++ b/cmd/tke-platform-api/app/options/feature.go
@@ -1,0 +1,65 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2021 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	flagNotFoundCRDProxy = "crd-proxy"
+)
+
+const (
+	configNotFoundCRDProxy = "features.crd_proxy"
+)
+
+const (
+	defaultNotFoundCRDProxy = false
+)
+
+// FeatureOptions contains the options that feature gate.
+type FeatureOptions struct {
+	NotFoundCRDProxy bool
+}
+
+// NewFeatureOptions creates an Options object with default feature parameters.
+func NewFeatureOptions() *FeatureOptions {
+	return &FeatureOptions{
+		NotFoundCRDProxy: defaultNotFoundCRDProxy,
+	}
+}
+
+// AddFlags adds flags for log to the specified FlagSet object.
+func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.Bool(flagNotFoundCRDProxy, o.NotFoundCRDProxy,
+		"Enable url proxy that can transfer custom resource.")
+	_ = viper.BindPFlag(configNotFoundCRDProxy, fs.Lookup(flagNotFoundCRDProxy))
+}
+
+// ApplyFlags parsing parameters from the command line or configuration file
+// to the options instance.
+func (o *FeatureOptions) ApplyFlags() []error {
+	var errs []error
+
+	o.NotFoundCRDProxy = viper.GetBool(configNotFoundCRDProxy)
+
+	return errs
+}

--- a/cmd/tke-platform-api/app/options/options.go
+++ b/cmd/tke-platform-api/app/options/options.go
@@ -2,7 +2,7 @@
  * Tencent is pleased to support the open source community by making TKEStack
  * available.
  *
- * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ * Copyright (C) 2012-2021 Tencent. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -39,6 +39,7 @@ type Options struct {
 	Authentication *apiserveroptions.AuthenticationWithAPIOptions
 	Authorization  *apiserveroptions.AuthorizationOptions
 	Audit          *genericapiserveroptions.AuditOptions
+	FeatureOptions *FeatureOptions
 }
 
 // NewOptions creates a new Options with a default config.
@@ -52,6 +53,7 @@ func NewOptions(serverName string) *Options {
 		Authentication: apiserveroptions.NewAuthenticationWithAPIOptions(),
 		Authorization:  apiserveroptions.NewAuthorizationOptions(),
 		Audit:          genericapiserveroptions.NewAuditOptions(),
+		FeatureOptions: NewFeatureOptions(),
 	}
 }
 
@@ -65,6 +67,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.Authentication.AddFlags(fs)
 	o.Authorization.AddFlags(fs)
 	o.Audit.AddFlags(fs)
+	o.FeatureOptions.AddFlags(fs)
 }
 
 // ApplyFlags parsing parameters from the command line or configuration file
@@ -79,6 +82,7 @@ func (o *Options) ApplyFlags() []error {
 	errs = append(errs, o.Generic.ApplyFlags()...)
 	errs = append(errs, o.Authentication.ApplyFlags()...)
 	errs = append(errs, o.Authorization.ApplyFlags()...)
+	errs = append(errs, o.FeatureOptions.ApplyFlags()...)
 
 	return errs
 }

--- a/cmd/tke-platform-api/app/server.go
+++ b/cmd/tke-platform-api/app/server.go
@@ -63,6 +63,7 @@ func createAPIServerConfig(cfg *config.Config) *apiserver.Config {
 			StorageFactory:          cfg.StorageFactory,
 			APIResourceConfigSource: cfg.StorageFactory.APIResourceConfigSource,
 			PrivilegedUsername:      cfg.PrivilegedUsername,
+			FeatureOptions:          cfg.FeatureOptions,
 		},
 	}
 }

--- a/pkg/platform/registry/cluster/storage/customresource_proxy.go
+++ b/pkg/platform/registry/cluster/storage/customresource_proxy.go
@@ -1,0 +1,161 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2021 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package storage
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
+	platforminternalclient "tkestack.io/tke/api/client/clientset/internalversion/typed/platform/internalversion"
+	"tkestack.io/tke/pkg/apiserver/authentication"
+	"tkestack.io/tke/pkg/platform/apiserver/filter"
+	"tkestack.io/tke/pkg/platform/proxy"
+)
+
+type CustomResourceHandler struct {
+	LoopbackClientConfig *rest.Config
+}
+
+var (
+	// Scheme is the default instance of runtime.Scheme to which types in the TKE API are already registered.
+	Scheme = runtime.NewScheme()
+	// Codecs provides access to encoding and decoding for the scheme
+	Codecs = serializer.NewCodecFactory(Scheme)
+
+	unversionedVersion = schema.GroupVersion{Group: "", Version: "v1"}
+	unversionedTypes   = []runtime.Object{
+		&metav1.Status{},
+	}
+)
+
+func init() {
+	Scheme.AddUnversionedTypes(unversionedVersion, unversionedTypes...)
+}
+
+// ServeHTTP is a proxy for unregister custom resource
+func (n *CustomResourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	requestInfo, ok := request.RequestInfoFrom(r.Context())
+	if !ok {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(fmt.Errorf("no RequestInfo found in the context")),
+			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+		)
+		return
+	}
+
+	// crd resource start with /apis
+	if requestInfo.APIPrefix != "apis" {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(fmt.Errorf("request crd is validate")),
+			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+		)
+		return
+	}
+
+	platformClient := platforminternalclient.NewForConfigOrDie(n.LoopbackClientConfig)
+	config, err := proxy.GetConfig(r.Context(), platformClient)
+
+	if err != nil {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+		)
+		return
+	}
+
+	TLSClientConfig := &tls.Config{}
+	TLSClientConfig.InsecureSkipVerify = true
+	if config.TLSClientConfig.CertData != nil && config.TLSClientConfig.KeyData != nil {
+		cert, err := tls.X509KeyPair(config.TLSClientConfig.CertData, config.TLSClientConfig.KeyData)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				apierrors.NewGenericServerResponse(http.StatusUnauthorized, requestInfo.Verb, schema.GroupResource{
+					Group:    requestInfo.APIGroup,
+					Resource: requestInfo.Resource,
+				}, requestInfo.Name,
+					err.Error(), 0, true),
+				Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+			)
+			return
+		}
+		TLSClientConfig.Certificates = []tls.Certificate{cert}
+	} else if config.BearerToken == "" {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewGenericServerResponse(http.StatusUnauthorized, requestInfo.Verb, schema.GroupResource{
+				Group:    requestInfo.APIGroup,
+				Resource: requestInfo.Resource,
+			}, requestInfo.Name,
+				fmt.Sprintf("%s has NO BearerToken", filter.ClusterFrom(r.Context())),
+				0, true),
+			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+		)
+		return
+	}
+
+	reserveProxy := httputil.NewSingleHostReverseProxy(&url.URL{
+		Scheme: "https",
+		Host:   config.Host,
+	})
+	reserveProxy.Transport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       TLSClientConfig,
+	}
+
+	reserveProxy.Director = buildDirector(r, config)
+	reserveProxy.FlushInterval = 100 * time.Millisecond
+	reserveProxy.ServeHTTP(w, r)
+}
+
+func buildDirector(r *http.Request, config *rest.Config) func(req *http.Request) {
+	clusterName := filter.ClusterFrom(r.Context())
+	userName, tenantID := authentication.UsernameAndTenantID(r.Context())
+	return func(req *http.Request) {
+		req.Header.Set(filter.ClusterNameHeaderKey, clusterName)
+		req.Header.Set("X-Remote-User", userName)
+		req.Header.Set("X-Remote-Extra-TenantID", tenantID)
+		if config.BearerToken != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", config.BearerToken))
+		}
+		req.URL = &url.URL{
+			Scheme: "https",
+			Host:   config.Host,
+			Path:   r.RequestURI,
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
支持url与集群中的crd请求连接相同，直接访问到集群的crd资源
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

支持通过正常http请求访问集群中crd资源。无需经过一下转发接口
```
/apis/platform.tkestack.io/v1/clusters/clusterName/proxy?path=
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

