### PR TITLE
fix bug in impersonation request

### DIFF
--- a/pkg/platform/registry/cluster/storage/proxy_test.go
+++ b/pkg/platform/registry/cluster/storage/proxy_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"testing"
+)
+
+type testCase struct {
+	host             string
+	proxyPath        string
+	expectedURL      string
+	expectedRawQuery string
+}
+
+func TestMakeURL(t *testing.T) {
+	var testCases = []testCase{
+		{
+			host:             "http://192.168.1.10:8888",
+			proxyPath:        "apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedURL:      "http://192.168.1.10:8888/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedRawQuery: "labelSelector=a.b.c/d.e=values1&limit=20",
+		},
+		{
+			host:             "https://192.168.1.10:8888/",
+			proxyPath:        "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedURL:      "https://192.168.1.10:8888/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedRawQuery: "labelSelector=a.b.c/d.e=values1&limit=20",
+		},
+		{
+			host:             "https://192.168.1.10:8888",
+			proxyPath:        "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+			expectedURL:      "https://192.168.1.10:8888/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+			expectedRawQuery: "",
+		},
+
+		{
+			host:             "http://192.168.1.10:8888/aaa/bbb",
+			proxyPath:        "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedURL:      "http://192.168.1.10:8888/aaa/bbb/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedRawQuery: "labelSelector=a.b.c/d.e=values1&limit=20",
+		},
+		{
+			host:             "http://192.168.1.10:8888/aaa/bbb",
+			proxyPath:        "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+			expectedURL:      "http://192.168.1.10:8888/aaa/bbb/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+			expectedRawQuery: "",
+		},
+		{
+			host:             "http://192.168.1.10",
+			proxyPath:        "apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedURL:      "http://192.168.1.10/apis/xxx.cloud.tencent.com/v1/namespaces/manifests?labelSelector=a.b.c/d.e=values1&limit=20",
+			expectedRawQuery: "labelSelector=a.b.c/d.e=values1&limit=20",
+		},
+	}
+
+	for index, tcase := range testCases {
+
+		uri, err := makeURL(tcase.host, tcase.proxyPath)
+		if err != nil || uri.String() != tcase.expectedURL || uri.RawQuery != tcase.expectedRawQuery {
+			t.Errorf("not pass test case %d\n", index)
+		}
+	}
+}
+
+func TestNonMakeURL(t *testing.T) {
+	var testCases = []testCase{
+		{
+			host:      "192.168.1.10:8888",
+			proxyPath: "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+		},
+		{
+			host:      "",
+			proxyPath: "/apis/xxx.cloud.tencent.com/v1/namespaces/manifests",
+		},
+	}
+
+	for index, tcase := range testCases {
+		_, err := makeURL(tcase.host, tcase.proxyPath) //should return an err
+		if err == nil {
+			t.Errorf("not pass test case %d\n", index)
+		}
+	}
+}


### PR DESCRIPTION



**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug

**What this PR does / why we need it**:

1. Exracting and valiating host and port by spliting string with
   keys is not reasonable. The original way will return a fake
   error with a valid host like http://192.168.1.11:8080/abc

2. request dose not support insert header with impersonation informations

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

