### PR TITLE
optimize application controller lock name

### DIFF
--- a/cmd/tke-application-controller/app/run.go
+++ b/cmd/tke-application-controller/app/run.go
@@ -91,7 +91,7 @@ func Run(cfg *config.Config, stopCh <-chan struct{}) error {
 
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id = id + "_" + string(uuid.NewUUID())
-	rl := resourcelock.NewApplication("tke-application-controller",
+	rl := resourcelock.NewApplication(cfg.ServerName,
 		cfg.LeaderElectionClient.ApplicationV1(),
 		resourcelock.Config{
 			Identity: id,
@@ -109,7 +109,7 @@ func Run(cfg *config.Config, stopCh <-chan struct{}) error {
 			},
 		},
 		WatchDog: electionChecker,
-		Name:     "tke-application-controller",
+		Name:     cfg.ServerName,
 	})
 	panic("unreachable")
 }


### PR DESCRIPTION
give a customized name to controller  leader's lock resource
in active-backup mode. It's already been implemented in platform
controller.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind feature


**What this PR does / why we need it**:

give a customized name to  application controller  lock resource.  To be consistent 
with platorm controller. 
