### PR TITLE
fix: stop using rbac v1beta1

### DIFF
--- a/cmd/tke-installer/app/installer/manifests/tke-audit-api/tke-audit-api.yaml
+++ b/cmd/tke-installer/app/installer/manifests/tke-audit-api/tke-audit-api.yaml
@@ -21,7 +21,7 @@ metadata:
   name: tke-audit-api
   namespace: tke
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -35,7 +35,7 @@ rules:
     resourceNames: ["tke-audit-api"]
     verbs: ["get", "update"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:

--- a/docs/guide/zh-CN/QuickStart/快速入门.md
+++ b/docs/guide/zh-CN/QuickStart/快速入门.md
@@ -107,7 +107,7 @@ TKEStack 还可以通过此处的蓝色按钮：**【新建独立集群】**和*
 
       ```yaml
       kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1beta1
+      apiVersion: rbac.authorization.k8s.io/v1
       metadata:
         name: admin
         annotations:

--- a/docs/guide/zh-CN/best-practices/jenkins.md
+++ b/docs/guide/zh-CN/best-practices/jenkins.md
@@ -165,7 +165,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jenkins2
 rules:
@@ -189,7 +189,7 @@ rules:
     verbs: ["get"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jenkins2

--- a/docs/guide/zh-CN/best-practices/offline-pot/roles/base-component/templates/elk/filebeat-k8s.yaml.j2
+++ b/docs/guide/zh-CN/best-practices/offline-pot/roles/base-component/templates/elk/filebeat-k8s.yaml.j2
@@ -152,7 +152,7 @@ spec:
           path: /var/lib/filebeat-data
           type: DirectoryOrCreate
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: filebeat
@@ -165,7 +165,7 @@ roleRef:
   name: filebeat
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: filebeat

--- a/docs/guide/zh-CN/products/platform/cluster.md
+++ b/docs/guide/zh-CN/products/platform/cluster.md
@@ -110,7 +110,7 @@ TKEStack还可以另外**新建独立集群**以及**导入已有集群**实现*
       ```yaml
       cat <<EOF | kubectl apply -f -
       kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1beta1
+      apiVersion: rbac.authorization.k8s.io/v1
       metadata:
         name: admin
         annotations:

--- a/pkg/monitor/controller/prometheus/controller.go
+++ b/pkg/monitor/controller/prometheus/controller.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+
 	"tkestack.io/tke/pkg/platform/util/addon"
 
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
@@ -965,7 +966,7 @@ func serviceAccountPrometheusOperator() *corev1.ServiceAccount {
 func clusterRolePrometheusOperator() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1171,7 +1172,7 @@ func serviceAccountPrometheus() *corev1.ServiceAccount {
 func clusterRolePrometheus() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1763,7 +1764,7 @@ func createServiceAccountForMetrics() *corev1.ServiceAccount {
 func createClusterRoleForMetrics() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1864,7 +1865,7 @@ func createClusterRoleBindingForMetrics() *rbacv1.ClusterRoleBinding {
 func createRoleForMetrics() *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -2434,7 +2435,7 @@ func createServiceAccountForNPD() *corev1.ServiceAccount {
 func createClusterRoleForNPD() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/tkestack/tke/issues/1756

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

