### PR TITLE
feat(platform): machine provider support OnHealthCheck interface

### DIFF
--- a/pkg/platform/controller/machine/machine_controller_test.go
+++ b/pkg/platform/controller/machine/machine_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	platformv1 "tkestack.io/tke/api/platform/v1"
+	machineprovider "tkestack.io/tke/pkg/platform/provider/machine"
 )
 
 func newMachineForTest(resourcesVersion string, spec *platformv1.MachineSpec, phase platformv1.MachinePhase, conditions []platformv1.MachineCondition) *platformv1.Machine {
@@ -41,7 +42,7 @@ func newMachineForTest(resourcesVersion string, spec *platformv1.MachineSpec, ph
 			Phase: platformv1.MachineRunning,
 			Conditions: []platformv1.MachineCondition{
 				{
-					Type:          conditionTypeHealthCheck,
+					Type:          machineprovider.ConditionTypeHealthCheck,
 					Status:        platformv1.ConditionTrue,
 					LastProbeTime: v1.Now(),
 				},
@@ -180,7 +181,7 @@ func TestController_needsUpdate(t *testing.T) {
 			name: "health check is not long enough",
 			args: func() args {
 				new := newMachineForTest("new", nil, platformv1.MachinePhase(""), []platformv1.MachineCondition{{
-					Type:          conditionTypeHealthCheck,
+					Type:          machineprovider.ConditionTypeHealthCheck,
 					Status:        platformv1.ConditionTrue,
 					LastProbeTime: v1.NewTime(time.Now().Add(-resyncInternal / 2))}})
 				return args{new, new}
@@ -191,7 +192,7 @@ func TestController_needsUpdate(t *testing.T) {
 			name: "health check is long enough",
 			args: func() args {
 				new := newMachineForTest("new", nil, platformv1.MachinePhase(""), []platformv1.MachineCondition{{
-					Type:          conditionTypeHealthCheck,
+					Type:          machineprovider.ConditionTypeHealthCheck,
 					Status:        platformv1.ConditionTrue,
 					LastProbeTime: v1.NewTime(time.Now().Add(-resyncInternal - 1))}})
 				return args{new, new}


### PR DESCRIPTION
Signed-off-by: malc0lm <malclee@outlook.com>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
The health checking use machine IP which acquired in tenant cluster node IP in machine controller. But in some scenario like [SuperEdge](https://github.com/superedge/superedge), we use the node name to get the node. So machine health checking always failed. 
In fact, health checking in provider need support user level implementation, this pr add `OnHealthCheck` in machine provider, and mv the origin default implementation in DelegateProvider.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

