### PR TITLE
feat(platform): support autoscaling v2beta2

### DIFF
--- a/pkg/platform/apiserver/apiserver.go
+++ b/pkg/platform/apiserver/apiserver.go
@@ -25,6 +25,7 @@ import (
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certv1beta1 "k8s.io/api/certificates/v1beta1"
@@ -227,6 +228,7 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 
 		autoscalingv1.SchemeGroupVersion,
 		autoscalingv2beta1.SchemeGroupVersion,
+		autoscalingv2beta2.SchemeGroupVersion,
 
 		appsv1.SchemeGroupVersion,
 		appsv1beta2.SchemeGroupVersion,

--- a/pkg/platform/apiserver/install.go
+++ b/pkg/platform/apiserver/install.go
@@ -34,6 +34,7 @@ import (
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2Beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certV1beta1 "k8s.io/api/certificates/v1beta1"
@@ -79,7 +80,9 @@ func Install(scheme *runtime.Scheme) {
 
 	runtimeutil.Must(autoscalingv1.AddToScheme(scheme))
 	runtimeutil.Must(autoscalingv2beta1.AddToScheme(scheme))
-	runtimeutil.Must(scheme.SetVersionPriority(autoscalingv1.SchemeGroupVersion, autoscalingv2beta1.SchemeGroupVersion))
+	runtimeutil.Must(autoscalingv2Beta2.AddToScheme(scheme))
+	runtimeutil.Must(scheme.SetVersionPriority(autoscalingv1.SchemeGroupVersion, autoscalingv2beta1.SchemeGroupVersion,
+		autoscalingv2Beta2.SchemeGroupVersion))
 
 	runtimeutil.Must(appsv1.AddToScheme(scheme))
 	runtimeutil.Must(appsv1beta1.AddToScheme(scheme))

--- a/pkg/platform/proxy/client.go
+++ b/pkg/platform/proxy/client.go
@@ -180,6 +180,8 @@ func RESTClientFor(clientSet *kubernetes.Clientset, apiGroup, apiVersion string)
 		return clientSet.AutoscalingV1().RESTClient()
 	case "autoscaling/v2beta1":
 		return clientSet.AutoscalingV2beta1().RESTClient()
+	case "autoscaling/v2beta2":
+		return clientSet.AutoscalingV2beta2().RESTClient()
 	case "batch/v1":
 		return clientSet.BatchV1().RESTClient()
 	case "batch/v1beta1":


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
tke-platform-api support "autoscaling v2beta2" rest api
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

