### PR TITLE
feat(platform): set default client qps unlimit if qps is not set

### DIFF
--- a/api/client/clientset/internalversion/typed/platform/internalversion/platform_client.go
+++ b/api/client/clientset/internalversion/typed/platform/internalversion/platform_client.go
@@ -134,10 +134,7 @@ func setConfigDefaults(config *rest.Config) error {
 	config.NegotiatedSerializer = scheme.Codecs
 
 	if config.QPS == 0 {
-		config.QPS = 5
-	}
-	if config.Burst == 0 {
-		config.Burst = 10
+		config.QPS = -1
 	}
 
 	return nil

--- a/api/client/clientset/versioned/typed/platform/v1/platform_client.go
+++ b/api/client/clientset/versioned/typed/platform/v1/platform_client.go
@@ -133,6 +133,9 @@ func setConfigDefaults(config *rest.Config) error {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
+	if config.QPS == 0 {
+		config.QPS = -1
+	}
 	return nil
 }
 

--- a/pkg/platform/provider/cluster/interface.go
+++ b/pkg/platform/provider/cluster/interface.go
@@ -46,8 +46,8 @@ const (
 	ReasonFailedInit   = "FailedInit"
 	ReasonFailedUpdate = "FailedUpdate"
 	ReasonFailedDelete = "FailedDelete"
-
-	ConditionTypeDone = "EnsureDone"
+	ConditionTypeDone  = "EnsureDone"
+	defaultQPS         = -1
 )
 
 type APIProvider interface {
@@ -433,7 +433,7 @@ func (p *DelegateProvider) getCurrentCondition(c *v1.Cluster, phase platformv1.C
 	return nil, errors.New("no condition need process")
 }
 
-// GetRestConfigV1 returns the cluster's rest config
+// GetRestConfig returns the cluster's rest config
 func (p *DelegateProvider) GetRestConfig(ctx context.Context, cluster *platformv1.Cluster, username string) (*rest.Config, error) {
 	cc, err := credential.GetClusterCredentialV1(ctx, p.PlatformClient, cluster, username)
 	if err != nil {
@@ -442,6 +442,9 @@ func (p *DelegateProvider) GetRestConfig(ctx context.Context, cluster *platformv
 	config := &rest.Config{}
 	if cc != nil {
 		config = cc.RESTConfig(cluster)
+	}
+	if config.QPS == 0 {
+		config.QPS = defaultQPS
 	}
 	return config, nil
 }

--- a/pkg/platform/types/types.go
+++ b/pkg/platform/types/types.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultTimeout = 30 * time.Second
-	defaultQPS     = 100
+	defaultQPS     = -1
 	defaultBurst   = 200
 )
 

--- a/pkg/platform/types/v1/types.go
+++ b/pkg/platform/types/v1/types.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	defaultTimeout = 30 * time.Second
-	defaultQPS     = 100
+	defaultQPS     = -1
 	defaultBurst   = 200
 )
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Set default qps form 5 to unlimited. default qps is too small for high frequency requests, which makes timeout if concurrent requests greater than 5
**Which issue(s) this PR fixes**:
`Fixes #<issue 1846>`

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

