### PR TITLE
fix(monitor): support configure vm alert rule

### DIFF
--- a/pkg/monitor/services/rest/types.go
+++ b/pkg/monitor/services/rest/types.go
@@ -53,6 +53,7 @@ const (
 	alarmPolicyTypeCluster = "cluster"
 	alarmPolicyTypeNode    = "node"
 	alarmPolicyTypePod     = "pod"
+	alarmPolicyTypeVM      = "virtualMachine"
 	alarmPolicyTypeKey     = "alarmPolicyType"
 	alarmObjectsTypeKey    = "alarmObjectsType"
 	filterNamespaceKey     = "namespace"
@@ -350,6 +351,21 @@ func (r *AlarmMetric) GetExpr(alarmPolicy *AlarmPolicy) string {
 		} else {
 			metric = r.MetricName
 		}
+	case alarmPolicyTypeVM:
+		filter := MetricFilter{}
+		if alarmPolicy.AlarmPolicySettings.AlarmObjects != "" {
+			alarmObjects := strings.Split(alarmPolicy.AlarmPolicySettings.AlarmObjects, ",")
+			filter.WorkloadName = strings.Join(alarmObjects, "|")
+		}
+		if alarmPolicy.Namespace != "" {
+			filter.Namespace = alarmPolicy.Namespace
+		}
+		if filter.WorkloadName != "" || filter.Namespace != "" {
+			metric = fmt.Sprintf("%s{%s}", r.MetricName, filter.ToStr())
+			metric = strings.ReplaceAll(metric, "workload_name", "name") //In vm metrics label, use name to replace workload_name
+		} else {
+			metric = r.MetricName
+		}
 	}
 	var value string
 	b, err := parseBool(r.Evaluator.Value)
@@ -407,6 +423,10 @@ func (r *AlarmMetric) GetAnnotations(alarmPolicy *AlarmPolicy) map[string]string
 	annotations[alarmObjectsTypeKey] = alarmPolicySettings.AlarmObjectsType
 	annotations[measurementKey] = r.Measurement
 	annotations[valueKey] = valueStr
+
+	if r.Unit == "%" { // if value is a percentage type, format the value for readable
+		annotations[valueKey] = "{{ $value | printf \"%.2f\" }}"
+	}
 	annotations[metricDisplayNameKey] = r.MetricDisplayName
 
 	return annotations

--- a/pkg/notify/apiserver/handler.go
+++ b/pkg/notify/apiserver/handler.go
@@ -45,6 +45,7 @@ const (
 	workloadKindKey       = "workloadKind"
 	namespaceKey          = "namespace"
 	workloadNameKey       = "workloadName"
+	virtualMachineKey     = "virtualMachine"
 	podNameKey            = "podName"
 	nodeNameKey           = "nodeName"
 	nodeRoleKey           = "nodeRole"
@@ -259,6 +260,11 @@ func getVariables(alert Alert) map[string]string {
 		summary = fmt.Sprintf("%s\n工作负载名称：%s", summary, workloadNameValue)
 	}
 
+	virtualMachineName, ok := labels["name"]
+	if ok {
+		summary = fmt.Sprintf("%s\n虚拟机名称：%s", summary, virtualMachineName)
+	}
+
 	namespaceValue, ok := labels["namespace"]
 	if ok {
 		summary = fmt.Sprintf("%s\n命名空间：%s", summary, namespaceValue)
@@ -297,6 +303,7 @@ func getVariables(alert Alert) map[string]string {
 	variables[evaluateValueKey] = evaluateValue
 	variables[metricDisplayNameKey] = metricDisplayNameValue
 	variables[summaryKey] = summary
+	variables[virtualMachineKey] = virtualMachineName
 
 	return variables
 }


### PR DESCRIPTION
1. fix alert rule expression for vm
2. add vm name in alert message
3. round values in prometheus alert annotation to two decimals

Signed-off-by: willzgli <willzgli@tencent.com>

**What type of PR is this?**

> /kind bug
