### PR TITLE
ci: use specific branch

### DIFF
--- a/.github/workflows/release-industry-cloud-1.9.yml
+++ b/.github/workflows/release-industry-cloud-1.9.yml
@@ -10,7 +10,7 @@ on:
   repository_dispatch:
     types: [release-industry-cloud-1.9]
   schedule:
-    - cron: "0 18 */3 * *"
+    - cron: "0 18 * * *"
   push:
     tags:
       - "v*.*.*"
@@ -38,9 +38,7 @@ jobs:
     steps:
       - name: Set VERSION
         run: |
-          echo ${GITHUB_REF#refs/*/}
-          echo ${GITHUB_REF}
-          echo "VERSION=${industry-cloud-1.9#refs/*/}" >> $GITHUB_ENV
+          echo "VERSION=industry-cloud-1.9" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.VERSION }}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

