### PR TITLE
fix(platform): get cluster client check cluster status

### DIFF
--- a/pkg/platform/proxy/client.go
+++ b/pkg/platform/proxy/client.go
@@ -72,6 +72,10 @@ func GetConfig(ctx context.Context, platformClient platforminternalclient.Platfo
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
 	}
 
+	if cluster.Status.Phase != platform.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
 	username, tenantID := authentication.UsernameAndTenantID(ctx)
 	if len(tenantID) > 0 && cluster.Spec.TenantID != tenantID {
 		return nil, errors.NewNotFound(platform.Resource("clusters"), cluster.ObjectMeta.Name)

--- a/pkg/platform/registry/cluster/storage/tappcontroller.go
+++ b/pkg/platform/registry/cluster/storage/tappcontroller.go
@@ -311,5 +311,10 @@ func buildClientSet(ctx context.Context, cluster *platform.Cluster, restConfig *
 	if cluster.Status.Locked != nil && *cluster.Status.Locked {
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
 	}
+
+	if cluster.Status.Phase != platform.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
 	return kubernetes.NewForConfig(restConfig)
 }

--- a/pkg/platform/util/addon/client.go
+++ b/pkg/platform/util/addon/client.go
@@ -55,6 +55,10 @@ func BuildExternalMonitoringClientSet(ctx context.Context, cluster *platformv1.C
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
 	}
 
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
 	return BuildExternalMonitoringClientSetNoStatus(ctx, cluster, client)
 }
 
@@ -79,6 +83,10 @@ func BuildKubeAggregatorClientSet(ctx context.Context, cluster *platformv1.Clust
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
 	}
 
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
 	return BuildKubeAggregatorClientSetNoStatus(ctx, cluster, client)
 }
 
@@ -98,6 +106,10 @@ func BuildExternalExtensionClientSetNoStatus(ctx context.Context, cluster *platf
 func BuildExternalExtensionClientSet(ctx context.Context, cluster *platformv1.Cluster, client platformversionedclient.PlatformV1Interface) (*apiextensionsclient.Clientset, error) {
 	if cluster.Status.Locked != nil && *cluster.Status.Locked {
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
+	}
+
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
 	}
 
 	return BuildExternalExtensionClientSetNoStatus(ctx, cluster, client)
@@ -137,6 +149,10 @@ func BuildExternalClientSet(ctx context.Context, cluster *platformv1.Cluster, cl
 
 	if cluster.Status.Locked != nil && *cluster.Status.Locked {
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
+	}
+
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
 	}
 
 	return util.BuildVersionedClientSet(cluster, credential)

--- a/pkg/platform/util/client.go
+++ b/pkg/platform/util/client.go
@@ -69,8 +69,12 @@ func DynamicClientByCluster(ctx context.Context, cluster *platform.Cluster, plat
 	if cluster.Status.Locked != nil && *cluster.Status.Locked {
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
 	}
-	return dynamic.NewForConfig(restConfig)
 
+	if cluster.Status.Phase != platform.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
+	return dynamic.NewForConfig(restConfig)
 }
 
 // ClientSetByCluster returns the backend kubernetes clientSet by given cluster object
@@ -139,6 +143,10 @@ func BuildExternalClientSet(ctx context.Context, cluster *platformv1.Cluster, cl
 
 	if cluster.Status.Locked != nil && *cluster.Status.Locked {
 		return nil, fmt.Errorf("cluster %s has been locked", cluster.ObjectMeta.Name)
+	}
+
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
 	}
 
 	return BuildVersionedClientSet(cluster, cc)

--- a/pkg/platform/util/location.go
+++ b/pkg/platform/util/location.go
@@ -53,6 +53,10 @@ func APIServerLocationByCluster(ctx context.Context, cluster *platformv1.Cluster
 		return nil, nil, "", errors.NewForbidden(platform.Resource("clusters"), cluster.ObjectMeta.Name, fmt.Errorf("cluster is been locked"))
 	}
 
+	if cluster.Status.Phase != platformv1.ClusterRunning {
+		return nil, nil, "", fmt.Errorf("cluster %s status is abnormal", cluster.ObjectMeta.Name)
+	}
+
 	provider, err := clusterprovider.GetProvider(cluster.Spec.Type)
 	if err != nil {
 		return nil, nil, "", errors.NewInternalError(err)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

