### PR TITLE
docs(quickstart): use `TokenRequest API` to create tokens when meet k8s version 1.24+

### DIFF
--- a/docs/guide/zh-CN/QuickStart/快速入门.md
+++ b/docs/guide/zh-CN/QuickStart/快速入门.md
@@ -134,15 +134,13 @@ TKEStack 还可以通过此处的蓝色按钮：**【新建独立集群】**和*
    2. 执行下面的命令创建 ServiceAccount 、 ClusterRole 、ClusterRoleBinding
 
       ```shell
-   kubectl create -f admin-role.yaml
+      $ kubectl create -f admin-role.yaml
       ```
 
    3. 创建完成后获取 Secret 中token的值
 
       ```shell
-
-      ```
-   # 获取admin-token的secret名字
+      # 获取admin-token的secret名字
       $ kubectl -n kube-system get secret|grep admin-token
       admin-token-nwphb                          kubernetes.io/service-account-token   3         6m
       # 获取token的值
@@ -150,10 +148,29 @@ TKEStack 还可以通过此处的蓝色按钮：**【新建独立集群】**和*
       Name:         admin-token-w4wcd
       Type:  kubernetes.io/service-account-token
       token:            非常长的字符串
-
       ```
 
-      ```
+> 注意从 Kubernetes 1.24 版本开始，不能再通过 `kubectl get secret` 获取 token 了，不过我们可以使用 TokenRequest API 来获取，首先开启代理：
+> 
+> ```
+> $ kubectl proxy --port=8001
+> Starting to serve on 127.0.0.1:8001
+> ```
+> 
+> 然后调用 TokenRequest API 生成一个 token：
+> 
+> ```
+> $ curl 'http://127.0.0.1:8001/api/v1/namespaces/kube-system/serviceaccounts/admin/token' \
+>     -H "Content-Type:application/json" -X POST -d '{}'
+> ```
+> 
+> 默认的 token 有效期只有一个小时，可以通过参数改为一年：
+> 
+> ```
+> $ curl 'http://127.0.0.1:8001/api/v1/namespaces/kube-system/serviceaccounts/admin/token' \
+>     -H "Content-Type:application/json" -X POST \
+>     -d '{"kind":"TokenRequest","apiVersion":"authentication.k8s.io/v1","metadata":{"name":"admin","namespace":"kube-system"},"spec":{"audiences":["https://kubernetes.default.svc.cluster.local"],"expirationSeconds":31536000}}'
+> ```
 
 #### TKEStack 中导入 Rancher 的 RKE 集群
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Kubernetes 在 1.24 之后的版本中，获取 token 的方式发生了变化，文档中需要添加相应的补充说明。