### PR TITLE
refactor(platform): set less info when check proxy

### DIFF
--- a/pkg/platform/provider/baremetal/validation/constants.go
+++ b/pkg/platform/provider/baremetal/validation/constants.go
@@ -1,0 +1,25 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack
+ * available.
+ *
+ * Copyright (C) 2012-2022 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package validation
+
+const (
+	AnywhereValidateItemTunnelConnectivity = "TunnelConnectivity"
+	AnywhereValidateItemSSH                = "SSH"
+	AnywhereValidateItemTimeDiff           = "TimeDiff"
+)

--- a/pkg/util/ssh/proxy.go
+++ b/pkg/util/ssh/proxy.go
@@ -62,7 +62,7 @@ func (sj JumpServer) ProxyConn(targetAddr string) (net.Conn, func(), error) {
 			closer()
 			log.Errorf("proxy %s dial %s failed: %v", sj.Host, targetAddr)
 		} else {
-			log.Infof("proxy %s dial %s sucess", sj.Host, targetAddr)
+			log.Debugf("proxy %s dial %s sucess", sj.Host, targetAddr)
 		}
 		r := result{conn: conn, err: err}
 		ch <- r


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

