### PR TITLE
fix(monitor): expose influxdb svc as nodeport

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -1970,9 +1970,6 @@ func (t *TKE) getInfluxDBOptions(ctx context.Context) (map[string]interface{}, e
 		}
 		options["nodeName"] = node.Name
 	}
-	if t.Para.Config.HA != nil && len(t.Para.Config.HA.VIP()) > 0 {
-		options["HA"] = true //for HA mode, enable NodePort
-	}
 	return options, nil
 }
 
@@ -2964,7 +2961,7 @@ func (t *TKE) patchClusterInfo(ctx context.Context, patchData interface{}) error
 }
 
 func (t *TKE) getLocalInfluxdbAddress() string {
-	var influxdbAddress string = "http://influxdb.tke.svc.cluster.local:8086"
+	var influxdbAddress string = fmt.Sprintf("http://%s:30086", t.servers[0])
 	if t.Para.Config.HA != nil && len(t.Para.Config.HA.VIP()) > 0 {
 		vip := t.Para.Config.HA.VIP()
 		influxdbAddress = fmt.Sprintf("http://%s:30086", vip) // influxdb svc must be set as NodePort type, and the nodePort is 30086

--- a/cmd/tke-installer/app/installer/manifests/charts/influxdb/templates/influxdb.yaml
+++ b/cmd/tke-installer/app/installer/manifests/charts/influxdb/templates/influxdb.yaml
@@ -117,9 +117,7 @@ spec:
       port: 8086
       targetPort: 8086
       protocol: TCP
-{{- if .Values.HA }}
       nodePort: 30086
   type: NodePort
-{{- end }}
   selector:
     app: influxdb

--- a/cmd/tke-upgrade/app/options/options.go
+++ b/cmd/tke-upgrade/app/options/options.go
@@ -323,7 +323,7 @@ func (t *TKE) TKERegistryAPI() (option Options) {
 }
 
 func (t *TKE) getLocalInfluxdbAddress() string {
-	var influxdbAddress string = "http://influxdb.tke.svc.cluster.local:8086"
+	var influxdbAddress string = fmt.Sprintf("http://%s:30086", t.Servers[0])
 	if t.Para.Config.HA != nil && len(t.Para.Config.HA.VIP()) > 0 {
 		vip := t.Para.Config.HA.VIP()
 		influxdbAddress = fmt.Sprintf("http://%s:30086", vip) // influxdb svc must be set as NodePort type, and the nodePort is 30086

--- a/pkg/monitor/apis/config/helpers_test.go
+++ b/pkg/monitor/apis/config/helpers_test.go
@@ -143,5 +143,6 @@ var (
 		"Storage.InfluxDB.Servers[*].TimeoutSeconds",
 		"Storage.InfluxDB.Servers[*].Username",
 		"Storage.Thanos.Servers[*].Address",
+		"Storage.InfluxDB.RetentionDays",
 	)
 )


### PR DESCRIPTION
expose influxdb svc as nodeport in non-ha mode  global cluster and ha mode global cluster. it will unify the remote writing address for promethues in global cluster and business cluster.

Signed-off-by: willzgli <willzgli@tencent.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

