### PR TITLE
fix:  alarm vm_cpu_usage_rate can over 100

### DIFF
--- a/web/console/src/modules/alarmPolicy/actions/validatorActions.ts
+++ b/web/console/src/modules/alarmPolicy/actions/validatorActions.ts
@@ -161,7 +161,7 @@ export const validatorActions = {
     }
     return { status, message };
   },
-  _validateEvaluatorValue(value: string) {
+  _validateEvaluatorValue(value: string, canOver100 = false) {
     let status = 0,
       message = '';
     if (!value) {
@@ -170,7 +170,7 @@ export const validatorActions = {
     } else if (isNaN(+value)) {
       status = 2;
       message = t('阈值的格式错误');
-    } else if (+value > 100 || +value <= 0) {
+    } else if ((+value > 100 && !canOver100) || +value <= 0) {
       status = 2;
       message = t('阈值的范围错误');
     } else {
@@ -210,7 +210,8 @@ export const validatorActions = {
         );
       } else {
         newAlarmMetrics[index].v_evaluatorValue = validatorActions._validateEvaluatorValue(
-          newAlarmMetrics[index].evaluatorValue
+          newAlarmMetrics[index].evaluatorValue,
+          newAlarmMetrics?.[index]?.metricName === 'vm_cpu_usage_rate'
         );
       }
 
@@ -234,7 +235,10 @@ export const validatorActions = {
         if (item.type === 'sumCpu' || item.type === 'sumMem') {
           isOk = isOk && validatorActions._validateEvaluatorSumValue(item.evaluatorValue + '').status === 1;
         } else if (item.type === 'times' || item.type === 'percent') {
-          isOk = isOk && validatorActions._validateEvaluatorValue(item.evaluatorValue + '').status === 1;
+          isOk =
+            isOk &&
+            validatorActions._validateEvaluatorValue(item.evaluatorValue + '', item?.metricName === 'vm_cpu_usage_rate')
+              .status === 1;
         }
       }
     });


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

