### PR TITLE
fix(console): vm status is running but not ready

### DIFF
--- a/web/console/src/modules/cluster/components/resource/virtual-machine/pages/detail/info/index.tsx
+++ b/web/console/src/modules/cluster/components/resource/virtual-machine/pages/detail/info/index.tsx
@@ -10,10 +10,15 @@ export const VMInfoPanel = ({ clusterId, namespace, name }) => {
     async () => {
       const { vm, vmi } = await virtualMachineAPI.fetchVMDetail({ clusterId, namespace, name });
 
+      let realStatus = vm?.status?.printableStatus;
+      if (realStatus === 'Running' && !vm?.status?.ready) {
+        realStatus = 'Abnormal';
+      }
+
       return {
         data: {
           description: vm?.metadata?.annotations?.description ?? '-',
-          status: vm?.status?.printableStatus,
+          status: realStatus,
           createTime: vm?.metadata?.creationTimestamp,
           tags: Object.entries(vmi?.metadata?.labels ?? [])
             .map(([key, value]) => `${key}：${value}`)

--- a/web/console/src/modules/cluster/components/resource/virtual-machine/pages/list/index.tsx
+++ b/web/console/src/modules/cluster/components/resource/virtual-machine/pages/list/index.tsx
@@ -137,18 +137,29 @@ export const VMListPanel = ({ route }) => {
       );
       return {
         data:
-          items.map(({ metadata, status, spec, vmi }) => ({
-            name: metadata?.name,
-            status: status?.printableStatus,
-            mirror: metadata?.annotations?.['tkestack.io/image-display-name'] ?? '-',
-            ip: vmi?.status?.interfaces?.[0]?.ipAddress ?? '-',
-            hardware: `${spec?.template?.spec?.domain?.cpu?.cores ?? '-'}核 / ${
-              spec?.template?.spec?.domain?.resources?.requests?.memory ?? '-'
-            }`,
-            createTime: metadata?.creationTimestamp,
+          items.map(({ metadata, status, spec, vmi }) => {
+            let realStatus = status?.printableStatus;
+            if (realStatus === 'Running' && !status?.ready) {
+              realStatus = 'Abnormal';
+            }
 
-            id: metadata?.uid
-          })) ?? [],
+            const failureCondition =
+              realStatus === 'Stopped' ? status?.conditions?.find(({ type }) => type === 'Failure') : null;
+
+            return {
+              name: metadata?.name,
+              status: realStatus,
+              failureCondition,
+              mirror: metadata?.annotations?.['tkestack.io/image-display-name'] ?? '-',
+              ip: vmi?.status?.interfaces?.[0]?.ipAddress ?? '-',
+              hardware: `${spec?.template?.spec?.domain?.cpu?.cores ?? '-'}核 / ${
+                spec?.template?.spec?.domain?.resources?.requests?.memory ?? '-'
+              }`,
+              createTime: metadata?.creationTimestamp,
+
+              id: metadata?.uid
+            };
+          }) ?? [],
 
         continueToken: newContinueToken,
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug

**What this PR does / why we need it**:
vm status为running，但是ready为false，此时vm实际状态是异常的，新增Abnormal表示此状态

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

