### PR TITLE
fix(installer): fix ingress chart raw values yaml no alignment

### DIFF
--- a/cmd/tke-installer/app/installer/installer.go
+++ b/cmd/tke-installer/app/installer/installer.go
@@ -2221,33 +2221,33 @@ func (t *TKE) installIngressChart(ctx context.Context) error {
  controller:
    name: controller
    image:
-	 registry: registry.tke.com
-	 image: library/ingress-nginx-controller
-	 tag: "v1.1.3"
-	 digest: ""
-	 pullPolicy: IfNotPresent
-	 runAsUser: 101
-	 allowPrivilegeEscalation: true
+     registry: registry.tke.com
+     image: library/ingress-nginx-controller
+     tag: "v1.1.3"
+     digest: ""
+     pullPolicy: IfNotPresent
+     runAsUser: 101
+     allowPrivilegeEscalation: true
    containerName: controller
    containerPort:
-	 http: 80
-	 https: 443
+     http: 80
+     https: 443
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    ingressClass: nginx
    kind: DaemonSet
    nodeSelector:
-	 node-role.kubernetes.io/master: ""
+     node-role.kubernetes.io/master: ""
    service:
-	 enabled: false
+     enabled: false
    admissionWebhooks:
-	 patch:
-	   enabled: true
-	   image:
-		 registry: registry.tke.com
-		 image: library/kube-webhook-certgen
-		 tag: "v1.1.1"
-		 digest: ""
+     patch:
+       enabled: true
+       image:
+         registry: registry.tke.com
+         image: library/kube-webhook-certgen
+         tag: "v1.1.1"
+         digest: ""
  `
 	tkeRegistry := &types.PlatformApp{
 		HelmInstallOptions: &helmaction.InstallOptions{


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:
Install ingress for global failed, because of unmarshaling rawValues failed for no alignment

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

