### PR TITLE
fix(logagent): correct dns policy for logagent daemonset

### DIFF
--- a/pkg/logagent/controller/logagent/logagent_controller.go
+++ b/pkg/logagent/controller/logagent/logagent_controller.go
@@ -597,6 +597,7 @@ func (c *Controller) genDaemonSet(version string) *appsv1.DaemonSet {
 					PriorityClassName:  "system-cluster-critical",
 					ServiceAccountName: svcAccountName,
 					HostNetwork:        true,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 					Tolerations: []corev1.Toleration{
 						{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
 					},


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:
The logagent has enabled hostNetwork, and the DNS policy is Clusterfirst. During domain name resolution, the pod inherits the domain name resolution configuration of the node, resulting in the inability to resolve domain names through kube-dns. The elasticsearch domain name resolution within the cluster fails. We need to modify the domain name resolution policy of the logagent to ClusterFirstWithHostNet.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

