### PR TITLE
fix(platform): adapt helmrelease new naming rule

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/create.go
+++ b/pkg/platform/provider/baremetal/cluster/create.go
@@ -1678,7 +1678,7 @@ func (p *Provider) EnsureCheckAnywhereSubscription(ctx context.Context, c *v1.Cl
 	_ = wait.PollImmediate(15*time.Second, 10*time.Minute, func() (bool, error) {
 		for i, feed := range sub.Spec.Feeds {
 			var helmrelease *appsv1alpha1.HelmRelease
-			helmrelease, err = extenderapi.GetHelmRelease(hubClient, extenderapi.GenerateHelmReleaseName(sub.Name, feed.Namespace, feed.Name), mcls.Namespace)
+			helmrelease, err = extenderapi.GetHelmRelease(hubClient, extenderapi.GenerateHelmReleaseName(sub.Namespace, sub.Name, feed.Namespace, feed.Name), mcls.Namespace)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return false, nil

--- a/pkg/util/extenderapi/extenderapi.go
+++ b/pkg/util/extenderapi/extenderapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	appsv1alpha1 "github.com/clusternet/apis/apps/v1alpha1"
 	clustersv1beta1 "github.com/clusternet/apis/clusters/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,7 +84,11 @@ func GetSubscription(clientSet client.Client, name, namespace string) (*appsv1al
 	return sub, nil
 }
 
-func GenerateHelmReleaseName(subName, componentNamespace, componentName string) string {
+func GenerateHelmReleaseName(subNamespace, subName, componentNamespace, componentName string) string {
+	// clusternet v0.15 changed helmreleaes name rule, ref https://github.com/clusternet/clusternet/pull/681
+	if len(subNamespace) != 0 {
+		return fmt.Sprintf("%s-%s-helm-%s-%s", subNamespace, subName, componentNamespace, componentName)
+	}
 	return fmt.Sprintf("%s-helm-%s-%s", subName, componentNamespace, componentName)
 }
 


### PR DESCRIPTION
Clusternet v0.15.3 has changed naming rule for new helmrelease This patch provided a compatible way to get helmrelease name.

For existing helmrelease, use old nameing rule
For newly created helmrelease, use new namimg rule
