### PR TITLE
feat(platform):add new cluster phase ClusterRecovering

### DIFF
--- a/api/platform/types.go
+++ b/api/platform/types.go
@@ -330,6 +330,8 @@ const (
 	ClusterUpscaling ClusterPhase = "Upscaling"
 	// ClusterDownscaling means the cluster is undergoing graceful down scaling.
 	ClusterDownscaling ClusterPhase = "Downscaling"
+	// ClusterRecovering means the cluster is recovering form confined.
+	ClusterRecovering ClusterPhase = "Recovering"
 )
 
 // ComponentPhase defines the phase of anywhere cluster component

--- a/api/platform/v1/types.go
+++ b/api/platform/v1/types.go
@@ -345,6 +345,8 @@ const (
 	ClusterUpscaling ClusterPhase = "Upscaling"
 	// ClusterDownscaling means the cluster is undergoing graceful down scaling.
 	ClusterDownscaling ClusterPhase = "Downscaling"
+	// ClusterRecovering means the cluster is recovering form confined.
+	ClusterRecovering ClusterPhase = "Recovering"
 )
 
 // ComponentPhase defines the phase of anywhere cluster component

--- a/pkg/platform/controller/cluster/cluster_controller.go
+++ b/pkg/platform/controller/cluster/cluster_controller.go
@@ -358,7 +358,7 @@ func (c *Controller) reconcile(ctx context.Context, key string, cluster *platfor
 		err = c.onUpdate(ctx, cluster)
 	case platformv1.ClusterUpscaling, platformv1.ClusterDownscaling:
 		err = c.onUpdate(ctx, cluster)
-	case platformv1.ClusterIdling, platformv1.ClusterConfined:
+	case platformv1.ClusterIdling, platformv1.ClusterConfined, platformv1.ClusterRecovering:
 		err = c.onUpdate(ctx, cluster)
 	case platformv1.ClusterTerminating:
 		log.FromContext(ctx).Info("Cluster has been terminated. Attempting to cleanup resources")
@@ -444,7 +444,8 @@ func (c *Controller) onUpdate(ctx context.Context, cluster *platformv1.Cluster) 
 	if clusterWrapper.Status.Phase == platformv1.ClusterRunning ||
 		clusterWrapper.Status.Phase == platformv1.ClusterFailed ||
 		clusterWrapper.Status.Phase == platformv1.ClusterIdling ||
-		clusterWrapper.Status.Phase == platformv1.ClusterConfined {
+		clusterWrapper.Status.Phase == platformv1.ClusterConfined ||
+		clusterWrapper.Status.Phase == platformv1.ClusterRecovering {
 		err = provider.OnUpdate(ctx, clusterWrapper)
 		clusterWrapper = c.checkHealth(ctx, clusterWrapper)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
kind feature

**What this PR does / why we need it**:
1) add new cluster phase ClusterRecovering，which means the cluster is recovering form confined.
2) the transition of State Machine wil be:
(normal phase) -> Idling -> Confined -> Recovering -> (normal phase)

**Special notes for your reviewer**:
1) eks use Annotations to Distinguish those phase.
2)tke use db record to Distinguish those phase.

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
NONE