### PR TITLE
fix: crd proxy path

### DIFF
--- a/pkg/platform/registry/cluster/storage/customresource_proxy.go
+++ b/pkg/platform/registry/cluster/storage/customresource_proxy.go
@@ -156,11 +156,7 @@ func buildDirector(r *http.Request, config *rest.Config) func(req *http.Request)
 		if config.BearerToken != "" {
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", config.BearerToken))
 		}
-		req.URL = &url.URL{
-			Scheme: "https",
-			// TODO: support apiserver with path
-			Host: strings.TrimPrefix(config.Host, "https://"),
-			Path: r.RequestURI,
-		}
+		req.URL.Scheme = "https"
+		req.URL.Host = strings.TrimPrefix(config.Host, "https://")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
CustomResourceHandler user r.RequestURI as Path. It will get 404 response when RequestURI has params, like /api/v1/namespaces?limit=500. The correct Path is /api/v1/namespaces, not /api/v1/namespaces?limit=500 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

